### PR TITLE
Publish the `parameters` module

### DIFF
--- a/gribberish/src/templates/product/mod.rs
+++ b/gribberish/src/templates/product/mod.rs
@@ -2,7 +2,7 @@ pub mod average_accumulation_extreme_horizontal_analysis_template;
 pub mod derived_ensemble_horizontal_analysis_template;
 pub mod derived_ensemble_horizontal_forecast_time_interval_template;
 pub mod horizontal_analysis_template;
-mod parameters;
+pub mod parameters;
 pub mod product_template;
 pub mod tables;
 

--- a/gribberish/src/templates/product/mod.rs
+++ b/gribberish/src/templates/product/mod.rs
@@ -1,11 +1,12 @@
+pub mod average_accumulation_extreme_horizontal_analysis_template;
+pub mod derived_ensemble_horizontal_analysis_template;
+pub mod derived_ensemble_horizontal_forecast_time_interval_template;
+pub mod horizontal_analysis_template;
+mod parameters;
 pub mod product_template;
 pub mod tables;
-pub mod horizontal_analysis_template;
-pub mod derived_ensemble_horizontal_analysis_template;
-pub mod average_accumulation_extreme_horizontal_analysis_template;
-pub mod derived_ensemble_horizontal_forecast_time_interval_template;
-mod parameters;
 
-pub use horizontal_analysis_template::HorizontalAnalysisForecastTemplate;
-pub use derived_ensemble_horizontal_analysis_template::DerivedEnsembleHorizontalAnalysisForecastTemplate;
 pub use average_accumulation_extreme_horizontal_analysis_template::AverageAccumulationExtremeHorizontalAnalysisForecastTemplate;
+pub use derived_ensemble_horizontal_analysis_template::DerivedEnsembleHorizontalAnalysisForecastTemplate;
+pub use horizontal_analysis_template::HorizontalAnalysisForecastTemplate;
+


### PR DESCRIPTION
As discussed in issue #59, this PR just changes `mod parameters` to `pub mod parameters`!

Sorry my tooling automatically put `mod.rs` into alphabetical order! (I actually didn't even know my toolchain reordered stuff without asking!) LMK if the re-ordering shouldn't be in this PR and I'll put the ordering back to how it was!

The `gribberish/gribberish` unit tests all pass.