### PR TITLE
Update message key to differentiate ensemble statistics

### DIFF
--- a/gribberish/src/message.rs
+++ b/gribberish/src/message.rs
@@ -105,6 +105,11 @@ impl<'a> Message<'a> {
             .unwrap_or("".into())
             .to_string();
         let var = self.variable_abbrev()?;
+        let derived_forecast_type = if let Some(dft) = self.derived_forecast_type()? {
+            dft.abbv()
+        } else {
+            "".into()
+        };
         let generating_process = self.generating_process()?.to_string();
         let statistical_process = self
             .statistical_process_type()
@@ -143,7 +148,7 @@ impl<'a> Message<'a> {
         };
 
         Ok(format!(
-            "{var}{time}{first_level}{second_level}:{statistical_process}{generating_process}"
+            "{var}{time}{first_level}{second_level}:{statistical_process}{generating_process}{derived_forecast_type}"
         ))
     }
 

--- a/gribberish/src/templates/product/tables.rs
+++ b/gribberish/src/templates/product/tables.rs
@@ -414,10 +414,41 @@ pub enum DerivedForecastType {
     ClimatePercentile = 197,
     DeviationOfMeanFromClimatology = 198,
     ExtremeForecastIndex = 199,
-    EquallyWeightedMena = 200,
+    EquallyWeightedMean = 200,
     FifthPercentile = 201,
     TwentyFifthPercentile = 202,
     SeventyFifthPercentile = 203,
     NinetyFifthPercentile = 204,
     Missing = 255,
+}
+
+impl DerivedForecastType {
+    pub fn abbv(&self) -> String {
+        match self {
+            DerivedForecastType::UnweightedMean => "mean".to_string(),
+            DerivedForecastType::WeightedMean => "wmean".to_string(),
+            DerivedForecastType::StandardDeviation => "stddev".to_string(),
+            DerivedForecastType::NormalizedStandardDeviation => "nstddev".to_string(),
+            DerivedForecastType::Spread => "spread".to_string(),
+            DerivedForecastType::LargeAnomaly => "lanomaly".to_string(),
+            DerivedForecastType::UnweightedMeanOfClustered => "uwmeanclustered".to_string(),
+            DerivedForecastType::InterquartileRange => "intquartrange".to_string(),
+            DerivedForecastType::Minimum => "min".to_string(),
+            DerivedForecastType::Maximum => "max".to_string(),
+            DerivedForecastType::UnweightedMode => "mode".to_string(),
+            DerivedForecastType::TenthPercentile => "10%".to_string(),
+            DerivedForecastType::FiftiethPercentile => "50%".to_string(),
+            DerivedForecastType::NinetiethPercentile => "90%".to_string(),
+            DerivedForecastType::StatisticallyWeighted => "statweighted".to_string(),
+            DerivedForecastType::ClimatePercentile => "clim%".to_string(),
+            DerivedForecastType::DeviationOfMeanFromClimatology => "devmeanfromclim".to_string(),
+            DerivedForecastType::ExtremeForecastIndex => "extremeforecastidx".to_string(),
+            DerivedForecastType::EquallyWeightedMean => "eqwmean".to_string(),
+            DerivedForecastType::FifthPercentile => "5%".to_string(),
+            DerivedForecastType::TwentyFifthPercentile => "25%".to_string(),
+            DerivedForecastType::SeventyFifthPercentile => "75%".to_string(),
+            DerivedForecastType::NinetyFifthPercentile => "90%".to_string(),
+            DerivedForecastType::Missing => "".to_string(),
+        }
+    }
 }


### PR DESCRIPTION
This allows the reader to distinguish between messages containing different forecast ensemble statistics as mentioned in https://github.com/mpiannucci/gribberish/issues/72#issuecomment-3180553909.  It doesn't resolve the issue of naming these variables in the dataset, but it does allow consumers of the Rust library to call `scan_message_metadata`.