### PR TITLE
Add cfgrib_compat flag and changes to backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -380,6 +380,7 @@ dependencies = [
 name = "gribberishpy"
 version = "0.23.0"
 dependencies = [
+ "chrono",
  "gribberish",
  "numpy",
  "pyo3",

--- a/gribberish/src/sections/identification.rs
+++ b/gribberish/src/sections/identification.rs
@@ -95,6 +95,22 @@ impl <'a> IdentificationSection<'a> {
     pub fn data_type(&self) -> GribDataType {
         self.data[20].into()
     }
+
+    pub fn originating_centre(&self) -> u16 {
+        read_u16_from_bytes(self.data, 5).unwrap_or(0)
+    }
+
+    pub fn originating_subcentre(&self) -> u16 {
+        read_u16_from_bytes(self.data, 7).unwrap_or(0)
+    }
+
+    pub fn master_tables_version(&self) -> u8 {
+        self.data[9]
+    }
+
+    pub fn local_tables_version(&self) -> u8 {
+        self.data[10]
+    }
 }
 
 impl <'a> GribSection for IdentificationSection<'a> {

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -12,3 +12,4 @@ crate-type = ["cdylib"]
 pyo3 = "0.26.0"
 gribberish = { path = "../gribberish", version = "0.23.0" }
 numpy = "0.26.0"
+chrono = "0.4"

--- a/python/gribberish/gribberish_backend.py
+++ b/python/gribberish/gribberish_backend.py
@@ -28,7 +28,8 @@ class GribberishBackend(BackendEntrypoint):
         perserve_dims=None,
         filter_by_attrs=None,
         filter_by_variable_attrs=None,
-        # other backend specific keyword arguments
+        # cfgrib_compat is accepted but currently a no-op
+        cfgrib_compat=False,
     ):
         storage_options = storage_options or {}
 
@@ -55,12 +56,13 @@ class GribberishBackend(BackendEntrypoint):
 
     open_dataset_parameters = [
         "filename_or_obj",
-        "drop_variables", 
-        "only_variables", 
-        "perserve_dims", 
-        "filter_by_attrs", 
-        "filter_by_variable_attrs", 
+        "drop_variables",
+        "only_variables",
+        "perserve_dims",
+        "filter_by_attrs",
+        "filter_by_variable_attrs",
         "storage_options",
+        "cfgrib_compat",
     ]
 
     def guess_can_open(self, filename_or_obj):

--- a/python/gribberish/gribberish_backend.py
+++ b/python/gribberish/gribberish_backend.py
@@ -28,7 +28,6 @@ class GribberishBackend(BackendEntrypoint):
         perserve_dims=None,
         filter_by_attrs=None,
         filter_by_variable_attrs=None,
-        # cfgrib_compat is accepted but currently a no-op
         cfgrib_compat=False,
     ):
         storage_options = storage_options or {}
@@ -37,14 +36,18 @@ class GribberishBackend(BackendEntrypoint):
             raw_data = f.read()
 
             dataset =  parse_grib_dataset(
-                raw_data, 
-                drop_variables=drop_variables, 
-                only_variables=only_variables, 
-                perserve_dims=perserve_dims, 
-                filter_by_attrs=filter_by_attrs, 
+                raw_data,
+                drop_variables=drop_variables,
+                only_variables=only_variables,
+                perserve_dims=perserve_dims,
+                filter_by_attrs=filter_by_attrs,
                 filter_by_variable_attrs=filter_by_variable_attrs,
             )
             coords = {k: (v['dims'], v['values'], v['attrs']) for (k, v) in dataset['coords'].items()}
+
+            if cfgrib_compat:
+                coords = {k: v for k, v in coords.items() if k not in ['x', 'y']}
+
             data_vars = {k: (v['dims'], GribberishBackendArray(filename_or_obj, storage_options=storage_options, array_metadata=v['values']) , v['attrs']) for (k, v) in dataset['data_vars'].items()}
             attrs = dataset['attrs']
 

--- a/python/gribberish/gribberish_backend.py
+++ b/python/gribberish/gribberish_backend.py
@@ -51,11 +51,18 @@ class GribberishBackend(BackendEntrypoint):
             data_vars = {k: (v['dims'], GribberishBackendArray(filename_or_obj, storage_options=storage_options, array_metadata=v['values']) , v['attrs']) for (k, v) in dataset['data_vars'].items()}
             attrs = dataset['attrs']
 
-            return xr.Dataset(
+            ds = xr.Dataset(
                 data_vars=data_vars,
                 coords=coords,
                 attrs=attrs
             )
+
+            if cfgrib_compat:
+                # Squeeze out dimensions with size 1 (time, level, etc.)
+                # drop=False keeps them as scalar coordinates
+                ds = ds.squeeze(drop=False)
+
+            return ds
 
     open_dataset_parameters = [
         "filename_or_obj",

--- a/python/gribberish/gribberish_backend.py
+++ b/python/gribberish/gribberish_backend.py
@@ -42,6 +42,7 @@ class GribberishBackend(BackendEntrypoint):
                 perserve_dims=perserve_dims,
                 filter_by_attrs=filter_by_attrs,
                 filter_by_variable_attrs=filter_by_variable_attrs,
+                cfgrib_compat=cfgrib_compat,
             )
             coords = {k: (v['dims'], v['values'], v['attrs']) for (k, v) in dataset['coords'].items()}
 

--- a/python/tests/test_xarray_backend.py
+++ b/python/tests/test_xarray_backend.py
@@ -1,0 +1,10 @@
+import numpy as np
+import xarray as xr
+
+
+def test_cfgrib_compat_removes_xy_coordinates():
+    ds = xr.open_dataset("./../gribberish/tests/data/hrrr.t06z.wrfsfcf01-TMP.grib2", engine="gribberish", cfgrib_compat=True)
+    assert "x" not in ds.coords, "x coordinate should be removed with cfgrib_compat=True"
+    assert "y" not in ds.coords, "y coordinate should be removed with cfgrib_compat=True"
+    assert "x" in ds.dims, "x dimension should still exist with cfgrib_compat=True"
+    assert "y" in ds.dims, "y dimension should still exist with cfgrib_compat=True"

--- a/python/tests/test_xarray_backend.py
+++ b/python/tests/test_xarray_backend.py
@@ -2,9 +2,36 @@ import numpy as np
 import xarray as xr
 
 
+def test_default_dtypes():
+    ds = xr.open_dataset("./../gribberish/tests/data/hrrr.t06z.wrfsfcf01-TMP.grib2", engine="gribberish")
+    # Data variables should be float32 by default
+    for var_name, var in ds.data_vars.items():
+        assert var.dtype == np.float32, f"Data variable {var_name} should be float32, got {var.dtype}"
+    # Coordinates should always be float64
+    for coord_name in ["latitude", "longitude", "x", "y"]:
+        if coord_name in ds.coords:
+            coord = ds.coords[coord_name]
+            assert coord.dtype == np.float64, f"Coordinate {coord_name} should be float64, got {coord.dtype}"
+
+
 def test_cfgrib_compat_removes_xy_coordinates():
     ds = xr.open_dataset("./../gribberish/tests/data/hrrr.t06z.wrfsfcf01-TMP.grib2", engine="gribberish", cfgrib_compat=True)
     assert "x" not in ds.coords, "x coordinate should be removed with cfgrib_compat=True"
     assert "y" not in ds.coords, "y coordinate should be removed with cfgrib_compat=True"
     assert "x" in ds.dims, "x dimension should still exist with cfgrib_compat=True"
     assert "y" in ds.dims, "y dimension should still exist with cfgrib_compat=True"
+
+
+def test_float64_values_dtype():
+    ds = xr.open_dataset(
+        "./../gribberish/tests/data/hrrr.t06z.wrfsfcf01-TMP.grib2",
+        engine="gribberish",
+        backend_kwargs={"values_dtype": np.dtype("float64")}
+    )
+    for var_name, var in ds.data_vars.items():
+        assert var.dtype == np.float64, f"Data variable {var_name} should be float64 when values_dtype=float64, got {var.dtype}"
+    # Coordinates should still be float64
+    for coord_name in ["latitude", "longitude", "x", "y"]:
+        if coord_name in ds.coords:
+            coord = ds.coords[coord_name]
+            assert coord.dtype == np.float64, f"Coordinate {coord_name} should be float64, got {coord.dtype}"


### PR DESCRIPTION
Following up on conversation from https://github.com/mpiannucci/gribberish/issues/88

This:
- add a `cfgrib_compat` argument that can be passed to the xarray backend
- adds a `values_dtype` argument like in cfgrib (default is `np.float32`)
- removes projection coordinates like cfgrib does when `cfgrib_compat=True`
- squeezes dimensions of size 1 when `cfgrib_compat=True`
- changes the definition of `time` to `fcast_time` (i.e. when the forecast was initialized) and adds a separate `valid_time` when `cfgrib_compat=True`

So there's one breaking change in there, though I'm not sure how many people are working with float64 data in GRIB (since most data is 12-24 bits integer encoded).

Here's the updated comparison, with `cfgrib_compat=True`:

cfgrib:
```
<xarray.Dataset> Size: 38MB
Dimensions:            (y: 1059, x: 1799)
Coordinates:
    time               datetime64[ns] 8B ...
    step               timedelta64[ns] 8B ...
    heightAboveGround  float64 8B ...
    latitude           (y, x) float64 15MB ...
    longitude          (y, x) float64 15MB ...
    valid_time         datetime64[ns] 8B ...
Dimensions without coordinates: y, x
Data variables:
    t2m                (y, x) float32 8MB ...
Attributes:
    GRIB_edition:            2
    GRIB_centre:             kwbc
    GRIB_centreDescription:  US National Weather Service - NCEP
    GRIB_subCentre:          0
    Conventions:             CF-1.7
    institution:             US National Weather Service - NCEP
    history:                 2025-11-07T19:34 GRIB to CDM+CF via cfgrib-0.9.15.1/ecCodes-2.44.0
```

and gribberish:
```
<xarray.Dataset> Size: 38MB
Dimensions:     (y: 1059, x: 1799)
Coordinates:
    time        datetime64[s] 8B ...
    step        timedelta64[s] 8B ...
    valid_time  datetime64[s] 8B ...
    latitude    (y, x) float64 15MB ...
    longitude   (y, x) float64 15MB ...
Dimensions without coordinates: y, x
Data variables:
    tmp         (y, x) float32 8MB ...
Attributes:
    GRIB_edition:    2
    GRIB_centre:     7
    GRIB_subCentre:  0
    Conventions:     CF-1.7
    institution:     GRIB centre 7
    history:         2025-11-07T19:34 GRIB to CDM+CF via gribberish-0.23.0
```