### PR TITLE
Bump version to 0.24.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -335,7 +335,7 @@ checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
 name = "gribberish"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "bitflags 2.6.0",
  "bitvec",
@@ -354,7 +354,7 @@ dependencies = [
 
 [[package]]
 name = "gribberish-macros"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "gribberish-types",
  "quote",
@@ -363,11 +363,11 @@ dependencies = [
 
 [[package]]
 name = "gribberish-types"
-version = "0.23.0"
+version = "0.24.0"
 
 [[package]]
 name = "gribberishjs"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "chrono",
  "gribberish",
@@ -378,7 +378,7 @@ dependencies = [
 
 [[package]]
 name = "gribberishpy"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "gribberish",
  "numpy",

--- a/gribberish/Cargo.toml
+++ b/gribberish/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gribberish"
-version = "0.23.0"
+version = "0.24.0"
 authors = ["Matthew Iannucci <mpiannucci@gmail.com>"]
 description = "Parse grib 2 files with Rust"
 edition = "2021"
@@ -10,8 +10,8 @@ keywords = ["grib", "weather", "meteorology", "climate", "oceanography"]
 categories = ["science", "encoding", "compression"]
 
 [dependencies]
-gribberish-types = { path = "../types", version = "0.23.0" }
-gribberish-macros = { path = "../macros", version = "0.23.0" }
+gribberish-types = { path = "../types", version = "0.24.0" }
+gribberish-macros = { path = "../macros", version = "0.24.0" }
 chrono = "0.4"
 openjpeg-sys = { version = "1.0.3", optional = true }
 png = { version = "0.17.2", optional = true }

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gribberish-macros"
-version = "0.23.0"
+version = "0.24.0"
 authors = ["Matthew Iannucci <mpiannucci@gmail.com>"]
 description = "Procedural macros for the gribberish crate"
 edition = "2021"
@@ -10,7 +10,7 @@ repository = "https://github.com/mpiannucci/gribberish"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-gribberish-types = { path = "./../types", version = "0.23.0" }
+gribberish-types = { path = "./../types", version = "0.24.0" }
 syn = { version = "1.0", features = ["full"] }
 quote = "1.0"
 

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "gribberishjs"
-version = "0.23.0"
+version = "0.24.0"
 
 [lib]
 crate-type = ["cdylib"]
@@ -10,7 +10,7 @@ crate-type = ["cdylib"]
 # Default enable napi4 feature, see https://nodejs.org/api/n-api.html#node-api-version-matrix
 napi = { version = "2.5.0", default-features = false, features = ["chrono_date"] }
 napi-derive = "2.5.0"
-gribberish = { path = "../gribberish", version = "0.23.0" }
+gribberish = { path = "../gribberish", version = "0.24.0" }
 chrono = "0.4"
 
 [build-dependencies]

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gribberishpy"
-version = "0.23.0"
+version = "0.24.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -10,5 +10,5 @@ crate-type = ["cdylib"]
 
 [dependencies]
 pyo3 = "0.26.0"
-gribberish = { path = "../gribberish", version = "0.23.0" }
+gribberish = { path = "../gribberish", version = "0.24.0" }
 numpy = "0.26.0"

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gribberish-types"
-version = "0.23.0"
+version = "0.24.0"
 authors = ["Matthew Iannucci <mpiannucci@gmail.com>"]
 description = "Common types for the gribberish crate"
 edition = "2021"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Bumps all workspace crates and inter-dependencies to 0.24.0 and updates Cargo.lock.
> 
> - **Version bumps**:
>   - Update `gribberish`, `gribberish-macros`, `gribberish-types`, `gribberishjs`, and `gribberishpy` from `0.23.0` to `0.24.0`.
>   - Align intra-workspace dependencies to `0.24.0` in `Cargo.toml` files (`gribberish`, `macros`, `node`, `python`).
> - **Lockfile**: Refresh `Cargo.lock` to reflect new versions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ec368c3a87b0eb32ff8fd4c0e66e8ac7b72e2c07. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->