### PR TITLE
Bump version to 0.25.0

### DIFF
--- a/gribberish/Cargo.toml
+++ b/gribberish/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gribberish"
-version = "0.24.0"
+version = "0.25.0"
 authors = ["Matthew Iannucci <mpiannucci@gmail.com>"]
 description = "Parse grib 2 files with Rust"
 edition = "2021"
@@ -11,8 +11,8 @@ categories = ["science", "encoding", "compression"]
 exclude = ["tests"]
 
 [dependencies]
-gribberish-types = { path = "../types", version = "0.24.0" }
-gribberish-macros = { path = "../macros", version = "0.24.0" }
+gribberish-types = { path = "../types", version = "0.25.0" }
+gribberish-macros = { path = "../macros", version = "0.25.0" }
 chrono = "0.4"
 openjpeg-sys = { version = "1.0.3", optional = true }
 png = { version = "0.17.2", optional = true }

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gribberish-macros"
-version = "0.24.0"
+version = "0.25.0"
 authors = ["Matthew Iannucci <mpiannucci@gmail.com>"]
 description = "Procedural macros for the gribberish crate"
 edition = "2021"
@@ -10,7 +10,7 @@ repository = "https://github.com/mpiannucci/gribberish"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-gribberish-types = { path = "./../types", version = "0.24.0" }
+gribberish-types = { path = "./../types", version = "0.25.0" }
 syn = { version = "1.0", features = ["full"] }
 quote = "1.0"
 

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "gribberishjs"
-version = "0.24.0"
+version = "0.25.0"
 
 [lib]
 crate-type = ["cdylib"]
@@ -10,7 +10,7 @@ crate-type = ["cdylib"]
 # Default enable napi4 feature, see https://nodejs.org/api/n-api.html#node-api-version-matrix
 napi = { version = "2.5.0", default-features = false, features = ["chrono_date"] }
 napi-derive = "2.5.0"
-gribberish = { path = "../gribberish", version = "0.24.0" }
+gribberish = { path = "../gribberish", version = "0.25.0" }
 chrono = "0.4"
 
 [build-dependencies]

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gribberishpy"
-version = "0.24.0"
+version = "0.25.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -10,5 +10,5 @@ crate-type = ["cdylib"]
 
 [dependencies]
 pyo3 = "0.26.0"
-gribberish = { path = "../gribberish", version = "0.24.0" }
+gribberish = { path = "../gribberish", version = "0.25.0" }
 numpy = "0.26.0"

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gribberish-types"
-version = "0.24.0"
+version = "0.25.0"
 authors = ["Matthew Iannucci <mpiannucci@gmail.com>"]
 description = "Common types for the gribberish crate"
 edition = "2021"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Bumps all crates and internal dependency pins to 0.25.0 across core, macros, types, Node, and Python bindings.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d3fff8da5e46b68ddb222ca083eba2d035a67211. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->