### PR TITLE
Add support for ECMWF GRIB1 table versions 128 and 228

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -335,7 +335,7 @@ checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
 name = "gribberish"
-version = "0.25.3"
+version = "0.27.0"
 dependencies = [
  "bitflags 2.6.0",
  "bitvec",
@@ -354,7 +354,7 @@ dependencies = [
 
 [[package]]
 name = "gribberish-macros"
-version = "0.25.3"
+version = "0.27.0"
 dependencies = [
  "gribberish-types",
  "quote",
@@ -363,11 +363,11 @@ dependencies = [
 
 [[package]]
 name = "gribberish-types"
-version = "0.25.3"
+version = "0.27.0"
 
 [[package]]
 name = "gribberishjs"
-version = "0.25.3"
+version = "0.27.0"
 dependencies = [
  "chrono",
  "gribberish",
@@ -378,7 +378,7 @@ dependencies = [
 
 [[package]]
 name = "gribberishpy"
-version = "0.25.3"
+version = "0.27.0"
 dependencies = [
  "gribberish",
  "numpy",
@@ -690,9 +690,9 @@ dependencies = [
 
 [[package]]
 name = "numpy"
-version = "0.26.0"
+version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b2dba356160b54f5371b550575b78130a54718b4c6e46b3f33a6da74a27e78b"
+checksum = "7aac2e6a6e4468ffa092ad43c39b81c79196c2bb773b8db4085f695efe3bba17"
 dependencies = [
  "libc",
  "ndarray",
@@ -760,9 +760,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.26.0"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ba0117f4212101ee6544044dae45abe1083d30ce7b29c4b5cbdfa2354e07383"
+checksum = "ab53c047fcd1a1d2a8820fe84f05d6be69e9526be40cb03b73f86b6b03e6d87d"
 dependencies = [
  "indoc",
  "libc",
@@ -777,18 +777,18 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.26.0"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fc6ddaf24947d12a9aa31ac65431fb1b851b8f4365426e182901eabfb87df5f"
+checksum = "b455933107de8642b4487ed26d912c2d899dec6114884214a0b3bb3be9261ea6"
 dependencies = [
  "target-lexicon",
 ]
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.26.0"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "025474d3928738efb38ac36d4744a74a400c901c7596199e20e45d98eb194105"
+checksum = "1c85c9cbfaddf651b1221594209aed57e9e5cff63c4d11d1feead529b872a089"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -796,9 +796,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.26.0"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e64eb489f22fe1c95911b77c44cc41e7c19f3082fc81cce90f657cdc42ffded"
+checksum = "0a5b10c9bf9888125d917fb4d2ca2d25c8df94c7ab5a52e13313a07e050a3b02"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -808,9 +808,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.26.0"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "100246c0ecf400b475341b8455a9213344569af29a3c841d29270e53102e0fcf"
+checksum = "03b51720d314836e53327f5871d4c0cfb4fb37cc2c4a11cc71907a86342c40f9"
 dependencies = [
  "heck",
  "proc-macro2",

--- a/gribberish/src/grib1/message.rs
+++ b/gribberish/src/grib1/message.rs
@@ -117,9 +117,10 @@ impl Grib1Message {
     /// Get parameter information
     pub fn parameter(&self) -> Option<(String, String, String)> {
         let center = self.pds.center_id();
+        let table_version = self.pds.parameter_table_version();
         let param_num = self.pds.parameter();
 
-        get_parameter(center, param_num).map(|p| {
+        get_parameter(center, table_version, param_num).map(|p| {
             (
                 p.abbreviation.to_string(),
                 p.name.to_string(),


### PR DESCRIPTION
## Summary
Fixes gribberish's ability to read GRIB1 files by adding missing ECMWF parameter definitions for table versions 128 and 228.

## Changes
1. **Added missing ECMWF table 128 parameters:**
   - 142: lsp (Large-scale precipitation)
   - 143: cp (Convective precipitation)
   - 176: ssr (Surface net short-wave (solar) radiation)

2. **Added support for ECMWF table 228 with parameters:**
   - 131: u10n (10 metre u-component of neutral wind)
   - 246: 100u (100 metre U wind component)
   - 247: 100v (100 metre V wind component)

3. **Updated `get_parameter()` function** to accept `table_version` parameter to distinguish between different ECMWF parameter tables

## Test plan
- [x] Verified reading GRIB1 files with both table versions
- [x] Unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)