### PR TITLE
Expose perturbation_number on GribMessageMetadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -444,7 +444,7 @@ checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
 name = "gribberish"
-version = "0.30.1"
+version = "0.30.3"
 dependencies = [
  "bitflags 2.6.0",
  "bitvec",
@@ -463,7 +463,7 @@ dependencies = [
 
 [[package]]
 name = "gribberish-macros"
-version = "0.30.1"
+version = "0.30.3"
 dependencies = [
  "gribberish-types",
  "quote",
@@ -472,11 +472,11 @@ dependencies = [
 
 [[package]]
 name = "gribberish-types"
-version = "0.30.1"
+version = "0.30.3"
 
 [[package]]
 name = "gribberish_js"
-version = "0.30.1"
+version = "0.30.3"
 dependencies = [
  "chrono",
  "gribberish",
@@ -487,7 +487,7 @@ dependencies = [
 
 [[package]]
 name = "gribberishpy"
-version = "0.30.1"
+version = "0.30.3"
 dependencies = [
  "gribberish",
  "numpy",

--- a/gribberish/Cargo.toml
+++ b/gribberish/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gribberish"
-version = "0.30.2"
+version = "0.30.3"
 authors = ["Matthew Iannucci <mpiannucci@gmail.com>"]
 description = "Parse grib 2 files with Rust"
 edition = "2021"
@@ -11,8 +11,8 @@ categories = ["science", "encoding", "compression"]
 exclude = ["tests"]
 
 [dependencies]
-gribberish-types = { path = "../types", version = "0.30.2" }
-gribberish-macros = { path = "../macros", version = "0.30.2" }
+gribberish-types = { path = "../types", version = "0.30.3" }
+gribberish-macros = { path = "../macros", version = "0.30.3" }
 chrono = "0.4"
 openjpeg-sys = { version = "1.0.3", optional = true }
 png = { version = "0.17.2", optional = true }

--- a/js/Cargo.toml
+++ b/js/Cargo.toml
@@ -3,7 +3,7 @@
 authors = ["Matthew Iannucci <mpiannucci@gmail.com>"]
 edition = "2024"
 name = "gribberish_js"
-version = "0.30.2"
+version = "0.30.3"
 
 [lib]
 crate-type = ["cdylib"]
@@ -11,11 +11,11 @@ crate-type = ["cdylib"]
 [dependencies]
 napi = { version = "3.0.0", features = ["chrono_date"] }
 napi-derive = "3.0.0"
-gribberish = { path = "../gribberish", version = "0.30.2", default-features = false, features = ["png"] }
+gribberish = { path = "../gribberish", version = "0.30.3", default-features = false, features = ["png"] }
 chrono = "0.4"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-gribberish = { path = "../gribberish", version = "0.30.2", default-features = false, features = ["png", "jpeg"] }
+gribberish = { path = "../gribberish", version = "0.30.3", default-features = false, features = ["png", "jpeg"] }
 
 [build-dependencies]
 napi-build = "2"

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mattnucc/gribberish",
-  "version": "0.30.2",
+  "version": "0.30.3",
   "description": "JavaScript bindings for gribberish, a GRIB2 parsing library",
   "main": "index.js",
   "repository": {

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gribberish-macros"
-version = "0.30.2"
+version = "0.30.3"
 authors = ["Matthew Iannucci <mpiannucci@gmail.com>"]
 description = "Procedural macros for the gribberish crate"
 edition = "2021"
@@ -10,7 +10,7 @@ repository = "https://github.com/mpiannucci/gribberish"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-gribberish-types = { path = "./../types", version = "0.30.2" }
+gribberish-types = { path = "./../types", version = "0.30.3" }
 syn = { version = "1.0", features = ["full"] }
 quote = "1.0"
 

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gribberishpy"
-version = "0.30.2"
+version = "0.30.3"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -10,5 +10,5 @@ crate-type = ["cdylib"]
 
 [dependencies]
 pyo3 = "0.27.0"
-gribberish = { path = "../gribberish", version = "0.30.2" }
+gribberish = { path = "../gribberish", version = "0.30.3" }
 numpy = "0.27.0"

--- a/python/src/message.rs
+++ b/python/src/message.rs
@@ -60,6 +60,11 @@ impl GribMessageMetadata {
     }
 
     #[getter]
+    fn perturbation_number(&self) -> Option<u8> {
+        self.inner.perturbation_number
+    }
+
+    #[getter]
     fn reference_date<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyDateTime>> {
         PyDateTime::from_timestamp(py, self.inner.reference_date.timestamp() as f64, None)
     }

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gribberish-types"
-version = "0.30.2"
+version = "0.30.3"
 authors = ["Matthew Iannucci <mpiannucci@gmail.com>"]
 description = "Common types for the gribberish crate"
 edition = "2021"


### PR DESCRIPTION
## Summary
- The ensemble perturbation number is already parsed from PDT 4.1 and 4.11 and stored on `MessageMetadata.perturbation_number`, but the Python `GribMessageMetadata` wrapper had no getter for it. Python callers had to either route through the dataset mapping or scan raw GRIB2 bytes themselves.
- Add a `perturbation_number` getter returning `Option<u8>` so it can be read directly off a message's metadata, alongside the existing fields.

## Test plan
- [ ] `cargo check` from `python/` (passes locally)
- [ ] Build the wheel (`maturin develop`) and confirm `metadata.perturbation_number` returns the expected value for an ensemble GRIB2 file (PDT 4.1 / 4.11) and `None` for a non-ensemble message

🤖 Generated with [Claude Code](https://claude.com/claude-code)