### PR TITLE
Add CF grid_mapping (spatial_ref) so tooling can recover the CRS

### DIFF
--- a/python/gribberish/virtualizarr/parser.py
+++ b/python/gribberish/virtualizarr/parser.py
@@ -130,10 +130,18 @@ def _inline_coord_array(name: str, coord: dict[str, Any]) -> ManifestArray:
         attrs.setdefault("units", "seconds since 1970-01-01 00:00:00")
         attrs.setdefault("calendar", "proleptic_gregorian")
 
-    arr = np.ascontiguousarray(arr)
+    # Capture the shape before making the buffer contiguous:
+    # np.ascontiguousarray promotes 0-d arrays to ndim >= 1, which would turn a
+    # scalar grid-mapping coordinate's () shape into (1,).
     shape = tuple(int(s) for s in arr.shape)
-    grid_shape = tuple([1] * len(shape)) if shape else (1,)
-    index = tuple([0] * len(grid_shape))
+    data = np.ascontiguousarray(arr).tobytes()
+
+    # One chunk covers the whole array, so the chunk grid mirrors the array's
+    # dimensionality: () for a scalar (e.g. the grid-mapping coordinate), and
+    # (1, 1, ...) otherwise. zarr requires the chunk grid and shape to share a
+    # rank, so a scalar must stay 0-d rather than being padded to (1,).
+    grid_shape = tuple([1] * len(shape))
+    index = tuple([0] * len(shape))
 
     paths = np.full(grid_shape, INLINED_CHUNK_PATH, dtype=np.dtypes.StringDType())
     offsets = np.zeros(grid_shape, dtype=np.uint64)
@@ -143,12 +151,12 @@ def _inline_coord_array(name: str, coord: dict[str, Any]) -> ManifestArray:
         paths=paths,
         offsets=offsets,
         lengths=lengths,
-        inlined={index: arr.tobytes()},
+        inlined={index: data},
     )
     metadata = create_v3_array_metadata(
         shape=shape,
         data_type=arr.dtype,
-        chunk_shape=shape if shape else (1,),
+        chunk_shape=shape,
         fill_value=None,
         codecs=[_BYTES_CODEC],
         attributes=attrs,

--- a/python/src/dataset.rs
+++ b/python/src/dataset.rs
@@ -86,6 +86,69 @@ fn node_has_data_vars(node: &Bound<'_, PyDict>) -> PyResult<bool> {
     Ok(data_vars.cast::<PyDict>()?.len() > 0)
 }
 
+/// Build the CF grid-mapping attributes for a projection, suitable for a
+/// `spatial_ref`-style scalar coordinate. Returns `None` for projections we
+/// don't have a CF name for, in which case no grid_mapping is emitted.
+///
+/// These attributes let geospatial tooling (rioxarray, cartopy, MetPy,
+/// cf_xarray) reconstruct the CRS via `pyproj.CRS.from_cf`, instead of callers
+/// hand-parsing the proj4 `crs` string. The existing per-variable `crs`/
+/// `proj_params` attrs are left untouched.
+fn cf_grid_mapping<'py>(
+    py: Python<'py>,
+    proj_name: &str,
+    params: &HashMap<String, f64>,
+) -> Option<Bound<'py, PyDict>> {
+    let attrs = PyDict::new(py);
+
+    // Earth shape: spherical -> earth_radius, otherwise the semi-axes.
+    let set_earth = |attrs: &Bound<'py, PyDict>| match (params.get("a"), params.get("b")) {
+        (Some(&a), Some(&b)) if (a - b).abs() < 1e-3 => {
+            attrs.set_item("earth_radius", a).unwrap();
+        }
+        (Some(&a), Some(&b)) => {
+            attrs.set_item("semi_major_axis", a).unwrap();
+            attrs.set_item("semi_minor_axis", b).unwrap();
+        }
+        _ => {}
+    };
+
+    match proj_name {
+        "latlon" => {
+            attrs
+                .set_item("grid_mapping_name", "latitude_longitude")
+                .unwrap();
+            set_earth(&attrs);
+        }
+        "lcc" => {
+            attrs
+                .set_item("grid_mapping_name", "lambert_conformal_conic")
+                .unwrap();
+            if let (Some(&lat_1), Some(&lat_2)) = (params.get("lat_1"), params.get("lat_2")) {
+                attrs
+                    .set_item("standard_parallel", vec![lat_1, lat_2])
+                    .unwrap();
+            }
+            if let Some(&lon_0) = params.get("lon_0") {
+                attrs
+                    .set_item("longitude_of_central_meridian", lon_0)
+                    .unwrap();
+            }
+            if let Some(&lat_0) = params.get("lat_0") {
+                attrs
+                    .set_item("latitude_of_projection_origin", lat_0)
+                    .unwrap();
+            }
+            attrs.set_item("false_easting", 0.0).unwrap();
+            attrs.set_item("false_northing", 0.0).unwrap();
+            set_earth(&attrs);
+        }
+        _ => return None,
+    }
+
+    Some(attrs)
+}
+
 #[pyfunction]
 #[pyo3(signature = (data, drop_variables=None, only_variables=None, perserve_dims=None, filter_by_attrs=None, filter_by_variable_attrs=None, encode_coords=None))]
 #[allow(clippy::too_many_arguments)]
@@ -900,6 +963,25 @@ fn build_group<'py>(
     coords.set_item("latitude", latitude).unwrap();
     coords.set_item("longitude", longitude).unwrap();
 
+    // CF grid mapping: a scalar `spatial_ref` coordinate carrying the CRS in a
+    // form geospatial tooling can auto-detect. Variables reference it via a
+    // `grid_mapping` attribute below.
+    let proj_name = first.2.projector.proj_name();
+    let proj_params = first.2.projector.proj_params();
+    let has_grid_mapping = if let Some(gm_attrs) = cf_grid_mapping(py, &proj_name, &proj_params) {
+        // Keep the proj4 string around for tools that prefer it over CF attrs.
+        gm_attrs.set_item("proj4", first.2.proj.clone()).unwrap();
+
+        let spatial_ref = PyDict::new(py);
+        spatial_ref.set_item("attrs", gm_attrs).unwrap();
+        spatial_ref.set_item("dims", Vec::<String>::new()).unwrap();
+        spatial_ref.set_item("values", 0i32).unwrap();
+        coords.set_item("spatial_ref", spatial_ref).unwrap();
+        true
+    } else {
+        false
+    };
+
     // Vars
     let data_vars = PyDict::new(py);
     for (var, v) in var_mapping.iter() {
@@ -1001,6 +1083,11 @@ fn build_group<'py>(
         var_metadata.set_item("proj_params", proj_params).unwrap();
 
         var_metadata.set_item("crs", first.2.proj.clone()).unwrap();
+
+        // Link the variable to the scalar `spatial_ref` grid-mapping coordinate.
+        if has_grid_mapping {
+            var_metadata.set_item("grid_mapping", "spatial_ref").unwrap();
+        }
 
         let mut filtered = false;
         if filter_by_variable_attrs_defined {

--- a/python/tests/test_virtualizarr.py
+++ b/python/tests/test_virtualizarr.py
@@ -115,6 +115,36 @@ def test_projected_grid_latlon_are_references():
     assert np.isfinite(lat).all()
 
 
+def test_cf_grid_mapping_scalar_coordinate():
+    """A scalar `spatial_ref` coordinate carries the CF grid mapping, and every
+    data variable links to it via a `grid_mapping` attribute. The 0-d coordinate
+    must round-trip through the manifest without being padded to shape (1,)."""
+    pyproj = pytest.importorskip("pyproj")
+
+    # Lambert conformal (HRRR) and a plain lat/lon grid (GFS).
+    cases = {
+        "hrrr.t06z.wrfsfcf01-TMP.grib2": "lambert_conformal_conic",
+        "gfs.t18z.pgrb2.0p25.f186-RH.grib2": "latitude_longitude",
+    }
+    for fname, grid_mapping_name in cases.items():
+        store = _store_for(fname)
+        vds = store.to_virtual_dataset()
+
+        assert "spatial_ref" in vds.coords
+        assert vds["spatial_ref"].shape == ()
+        assert vds["spatial_ref"].attrs["grid_mapping_name"] == grid_mapping_name
+
+        data_vars = [v for v in vds.data_vars if v != "spatial_ref"]
+        assert data_vars
+        for name in data_vars:
+            assert vds[name].attrs["grid_mapping"] == "spatial_ref"
+
+        # CF attributes reconstruct the same CRS as the proj4 string.
+        attrs = vds["spatial_ref"].attrs
+        cf = {k: v for k, v in attrs.items() if k != "proj4"}
+        assert pyproj.CRS.from_cf(cf) == pyproj.CRS.from_proj4(attrs["proj4"])
+
+
 def test_ensemble_member_dimension():
     """Ensemble member number is a dimension, not a group."""
     store = _store_for("aifs-ens-cf-t500.grib2")

--- a/python/tests/test_xarray_backend.py
+++ b/python/tests/test_xarray_backend.py
@@ -351,3 +351,27 @@ def test_xarray_backend_s2s_percentile_probability():
     for gname in (g for g in groups if "prob" in g):
         prob = xr.open_dataset(path, engine="gribberish", group=gname)
         assert "percentile" not in prob.tmp.dims
+
+
+def test_cf_grid_mapping_metadata():
+    """The backend emits a scalar `spatial_ref` grid-mapping coordinate and
+    links each variable to it, so geospatial tooling can recover the CRS."""
+    pyproj = pytest.importorskip("pyproj")
+
+    cases = {
+        "./../test-data/hrrr.t06z.wrfsfcf01-TMP.grib2": "lambert_conformal_conic",
+        "./../test-data/gfs.t18z.pgrb2.0p25.f186-RH.grib2": "latitude_longitude",
+    }
+    for path, grid_mapping_name in cases.items():
+        ds = xr.open_dataset(path, engine="gribberish")
+
+        assert "spatial_ref" in ds.coords
+        assert ds["spatial_ref"].shape == ()
+        assert ds["spatial_ref"].attrs["grid_mapping_name"] == grid_mapping_name
+
+        for name in ds.data_vars:
+            assert ds[name].attrs["grid_mapping"] == "spatial_ref"
+
+        attrs = ds["spatial_ref"].attrs
+        cf = {k: v for k, v in attrs.items() if k != "proj4"}
+        assert pyproj.CRS.from_cf(cf) == pyproj.CRS.from_proj4(attrs["proj4"])


### PR DESCRIPTION
Adds a CF-standard `grid_mapping` so tools like rioxarray, cartopy, and cf_xarray can auto-detect the CRS, instead of hand-parsing the proj4 `crs` string.

Each dataset gains a scalar `spatial_ref` coordinate with CF grid-mapping attributes, and each variable gets a `grid_mapping: "spatial_ref"` attr. Maps `lcc` → `lambert_conformal_conic` and `latlon` → `latitude_longitude`. Done in `dataset.rs`, so both the xarray backend and virtualizarr parser get it. Existing `crs`/`proj_params` attrs are kept (additive, non-breaking).

Also fixes a virtualizarr bug: `np.ascontiguousarray` promotes 0-d arrays to `(1,)`, which broke the new scalar coordinate. Now the shape is captured before making the buffer contiguous.

Tests cover both paths for Lambert (HRRR) and lat/lon (GFS), asserting `CRS.from_cf` == `CRS.from_proj4`. Full suite passes; clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)