### PR TITLE
Bump version to 1.0.1

### DIFF
--- a/.claude/skills/bump-version/SKILL.md
+++ b/.claude/skills/bump-version/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: bump-version
+description: Bump the version of every gribberish crate and package (the three Rust crates, the Python extension, and the npm package) in lockstep to a requested value, and regenerate Cargo.lock. Use when asked to bump, set, or change the version, cut a release, or prepare a new version of gribberish.
+---
+
+# bump-version
+
+gribberish is a Cargo workspace whose five crates plus its npm package all share
+**one** version, kept in lockstep. A version bump is not a single edit: each
+manifest carries a `[package] version`, internal path-dependencies pin that same
+version, and `Cargo.lock` records it for every crate. Miss one and `cargo` /
+`napi` / `maturin` disagree at publish time.
+
+The driver `bump_version.py` does all of it. **Always use it** — don't hand-edit
+manifests.
+
+All paths below are relative to the repo root (the directory with the workspace
+`Cargo.toml`). Run from there.
+
+## What carries the version
+
+- `types/Cargo.toml`, `macros/Cargo.toml`, `gribberish/Cargo.toml`,
+  `python/Cargo.toml`, `js/Cargo.toml` — each `[package] version`, plus every
+  internal `gribberish*` path-dependency's `version = "..."`.
+- `js/package.json` — top-level `"version"`.
+- `Cargo.lock` — the five workspace crate entries (regenerated, not edited).
+- `python/pyproject.toml` does **not** carry a version — it's `dynamic` and
+  maturin reads it from `python/Cargo.toml`. Leave it alone.
+
+## Run (agent path)
+
+```bash
+# What's the current version?
+python3 .claude/skills/bump-version/bump_version.py --current
+
+# Dry run — show which files/lines would change, write nothing.
+python3 .claude/skills/bump-version/bump_version.py 1.2.0 --check
+
+# Apply the bump (edits manifests + regenerates Cargo.lock).
+python3 .claude/skills/bump-version/bump_version.py 1.2.0
+
+# Review, then commit.
+git diff
+```
+
+A clean bump prints the per-file line counts (e.g. `gribberish/Cargo.toml: 3
+line(s)`) and ends with `Cargo.lock updated.` The expected footprint is **7
+files, 17 insertions / 17 deletions** — if `git diff --stat` shows more or
+fewer files, something is off.
+
+The version argument must be valid semver (`1.2.0`, `2.0.0-rc.1`). The script
+refuses anything else, refuses to run outside the workspace root, and is
+idempotent (re-running at the current version is a no-op).
+
+## Gotchas
+
+- **External deps are never touched.** The script only rewrites internal
+  `version` fields that sit behind a `path = "..."` (the `gribberish*` crates).
+  `napi = "3.0.0"`, `pyo3 = "0.27.0"`, `numpy`, etc. have no `path`, so they're
+  safe — that's why a bare find-and-replace of the version string is *not* what
+  this does.
+- **Consistency is enforced up front.** If the manifests don't already agree on
+  one current version, the script aborts and lists the disagreement instead of
+  bumping. Resolve the drift first.
+- **`Cargo.lock` is regenerated via `cargo update --workspace`**, not text-edited.
+  It tries `--offline` first and falls back to online if the lock needs a
+  registry fetch. If you have no network and the lock is stale, that fallback
+  can fail — run `cargo update --workspace` once with network, then re-run.
+- **This bumps versions only.** It does not tag, publish, or push. Publishing
+  the crates / npm package / wheels is a separate step.
+
+## Troubleshooting
+
+- `ERROR: run this from the repo root` — you're in a subdirectory. `cd` to the
+  workspace root (where the `[workspace]` `Cargo.toml` lives).
+- `ERROR: manifests disagree on current version` — a previous partial edit left
+  things inconsistent. The error lists each file's version; reconcile them
+  (usually `git checkout` the stray file) and re-run.
+- `ERROR: cargo update failed` — `cargo` couldn't refresh the lock (often
+  offline + stale lock). Run `cargo update --workspace` manually to see the real
+  error.

--- a/.claude/skills/bump-version/bump_version.py
+++ b/.claude/skills/bump-version/bump_version.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""Bump the version of every gribberish crate / package in lockstep.
+
+All five crates (gribberish-types, gribberish-macros, gribberish, gribberishpy,
+gribberish_js) and the npm package (@mattnucc/gribberish) share ONE version.
+Internal path-dependencies pin that same version, so a bump touches both the
+`[package] version` line and every internal `{ path = ..., version = ... }` ref.
+
+Usage:
+    python3 bump_version.py <new-version>          # apply the bump
+    python3 bump_version.py <new-version> --check   # dry run, show planned edits
+    python3 bump_version.py --current               # print current version and exit
+
+Run from the repo root (the directory containing the workspace Cargo.toml).
+After editing manifests this regenerates Cargo.lock via `cargo update`.
+"""
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+# Manifests carrying a version. Paths are relative to the repo root.
+CARGO_TOMLS = [
+    "types/Cargo.toml",
+    "macros/Cargo.toml",
+    "gribberish/Cargo.toml",
+    "python/Cargo.toml",
+    "js/Cargo.toml",
+]
+PACKAGE_JSONS = ["js/package.json"]
+
+# `[package] version = "X"` — line-anchored, so it never matches the
+# version field inside an inline `{ ... }` dependency table.
+PKG_VERSION_RE = re.compile(r'(?m)^version = "[^"]+"')
+# Internal path-dependency version: `... path = "..", version = "X" ..`.
+# Keyed on a preceding `path = "..."`, so external deps (napi, pyo3, numpy,
+# which have no `path`) are left untouched.
+PATH_DEP_RE = re.compile(r'(path\s*=\s*"[^"]*",\s*version\s*=\s*")[^"]+(")')
+# Top-level npm `"version": "X"`.
+JSON_VERSION_RE = re.compile(r'("version":\s*")[^"]+(")')
+
+SEMVER_RE = re.compile(r"^\d+\.\d+\.\d+([-+].+)?$")
+
+
+def read_current(root: Path) -> str:
+    """Return the version every manifest agrees on, or die if they disagree."""
+    found = {}
+    for rel in CARGO_TOMLS:
+        text = (root / rel).read_text()
+        m = PKG_VERSION_RE.search(text)
+        if not m:
+            sys.exit(f"ERROR: no [package] version in {rel}")
+        found[rel] = m.group(0).split('"')[1]
+    for rel in PACKAGE_JSONS:
+        text = (root / rel).read_text()
+        m = JSON_VERSION_RE.search(text)
+        if not m:
+            sys.exit(f"ERROR: no version field in {rel}")
+        found[rel] = m.group(0).split('"')[3]
+    versions = set(found.values())
+    if len(versions) != 1:
+        lines = "\n".join(f"  {k}: {v}" for k, v in found.items())
+        sys.exit(f"ERROR: manifests disagree on current version:\n{lines}")
+    return versions.pop()
+
+
+def plan_edits(root: Path, new: str) -> dict:
+    """Compute new file contents. Returns {relpath: (old_text, new_text)}."""
+    edits = {}
+    for rel in CARGO_TOMLS:
+        text = (root / rel).read_text()
+        out = PKG_VERSION_RE.sub(f'version = "{new}"', text, count=1)
+        out = PATH_DEP_RE.sub(rf'\g<1>{new}\g<2>', out)
+        if out != text:
+            edits[rel] = (text, out)
+    for rel in PACKAGE_JSONS:
+        text = (root / rel).read_text()
+        out = JSON_VERSION_RE.sub(rf'\g<1>{new}\g<2>', text, count=1)
+        if out != text:
+            edits[rel] = (text, out)
+    return edits
+
+
+def main() -> None:
+    args = sys.argv[1:]
+    root = Path.cwd()
+    if not (root / "Cargo.toml").exists() or "[workspace]" not in (root / "Cargo.toml").read_text():
+        sys.exit("ERROR: run this from the repo root (the workspace Cargo.toml dir).")
+
+    if args == ["--current"]:
+        print(read_current(root))
+        return
+
+    check = "--check" in args
+    positional = [a for a in args if not a.startswith("--")]
+    if len(positional) != 1:
+        sys.exit("Usage: bump_version.py <new-version> [--check] | --current")
+    new = positional[0]
+    if not SEMVER_RE.match(new):
+        sys.exit(f"ERROR: '{new}' is not a valid semver (e.g. 1.2.0, 1.0.0-rc.1).")
+
+    current = read_current(root)
+    print(f"Current version: {current}")
+    print(f"Target  version: {new}")
+    if current == new:
+        print("Already at target version; nothing to do.")
+        return
+
+    edits = plan_edits(root, new)
+    for rel in sorted(edits):
+        changed = sum(
+            1 for a, b in zip(edits[rel][0].splitlines(), edits[rel][1].splitlines()) if a != b
+        )
+        print(f"  {rel}: {changed} line(s)")
+
+    if check:
+        print("\n--check: no files written.")
+        return
+
+    for rel, (_, out) in edits.items():
+        (root / rel).write_text(out)
+    print(f"\nWrote {len(edits)} manifest(s). Regenerating Cargo.lock...")
+
+    # Refresh the workspace crate versions in Cargo.lock without touching deps.
+    r = subprocess.run(
+        ["cargo", "update", "--workspace", "--offline"],
+        cwd=root, capture_output=True, text=True,
+    )
+    if r.returncode != 0:
+        # --offline can fail if the lock needs a registry fetch; retry online.
+        r = subprocess.run(
+            ["cargo", "update", "--workspace"],
+            cwd=root, capture_output=True, text=True,
+        )
+    if r.returncode != 0:
+        print(r.stderr, file=sys.stderr)
+        sys.exit("ERROR: `cargo update` failed; Cargo.lock not regenerated.")
+
+    locked = read_current(root)  # re-validate manifests are consistent
+    print(f"Done. All manifests now at {locked}. Cargo.lock updated.")
+    print("Review with: git diff")
+
+
+if __name__ == "__main__":
+    main()

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -444,7 +444,7 @@ checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
 name = "gribberish"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "bitflags 2.6.0",
  "bitvec",
@@ -463,7 +463,7 @@ dependencies = [
 
 [[package]]
 name = "gribberish-macros"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "gribberish-types",
  "quote",
@@ -472,11 +472,11 @@ dependencies = [
 
 [[package]]
 name = "gribberish-types"
-version = "1.0.0"
+version = "1.0.1"
 
 [[package]]
 name = "gribberish_js"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "chrono",
  "gribberish",
@@ -487,7 +487,7 @@ dependencies = [
 
 [[package]]
 name = "gribberishpy"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "gribberish",
  "numpy",

--- a/gribberish/Cargo.toml
+++ b/gribberish/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gribberish"
-version = "1.0.0"
+version = "1.0.1"
 authors = ["Matthew Iannucci <mpiannucci@gmail.com>"]
 description = "Parse grib 2 files with Rust"
 edition = "2021"
@@ -11,8 +11,8 @@ categories = ["science", "encoding", "compression"]
 exclude = ["tests"]
 
 [dependencies]
-gribberish-types = { path = "../types", version = "1.0.0" }
-gribberish-macros = { path = "../macros", version = "1.0.0" }
+gribberish-types = { path = "../types", version = "1.0.1" }
+gribberish-macros = { path = "../macros", version = "1.0.1" }
 chrono = "0.4"
 openjpeg-sys = { version = "1.0.3", optional = true }
 png = { version = "0.17.2", optional = true }

--- a/js/Cargo.toml
+++ b/js/Cargo.toml
@@ -3,7 +3,7 @@
 authors = ["Matthew Iannucci <mpiannucci@gmail.com>"]
 edition = "2024"
 name = "gribberish_js"
-version = "1.0.0"
+version = "1.0.1"
 
 [lib]
 crate-type = ["cdylib"]
@@ -11,11 +11,11 @@ crate-type = ["cdylib"]
 [dependencies]
 napi = { version = "3.0.0", features = ["chrono_date"] }
 napi-derive = "3.0.0"
-gribberish = { path = "../gribberish", version = "1.0.0", default-features = false, features = ["png"] }
+gribberish = { path = "../gribberish", version = "1.0.1", default-features = false, features = ["png"] }
 chrono = "0.4"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-gribberish = { path = "../gribberish", version = "1.0.0", default-features = false, features = ["png", "jpeg"] }
+gribberish = { path = "../gribberish", version = "1.0.1", default-features = false, features = ["png", "jpeg"] }
 
 [build-dependencies]
 napi-build = "2"

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mattnucc/gribberish",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "JavaScript bindings for gribberish, a GRIB2 parsing library",
   "main": "index.js",
   "repository": {

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gribberish-macros"
-version = "1.0.0"
+version = "1.0.1"
 authors = ["Matthew Iannucci <mpiannucci@gmail.com>"]
 description = "Procedural macros for the gribberish crate"
 edition = "2021"
@@ -10,7 +10,7 @@ repository = "https://github.com/mpiannucci/gribberish"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-gribberish-types = { path = "./../types", version = "1.0.0" }
+gribberish-types = { path = "./../types", version = "1.0.1" }
 syn = { version = "1.0", features = ["full"] }
 quote = "1.0"
 

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gribberishpy"
-version = "1.0.0"
+version = "1.0.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -10,5 +10,5 @@ crate-type = ["cdylib"]
 
 [dependencies]
 pyo3 = "0.27.0"
-gribberish = { path = "../gribberish", version = "1.0.0" }
+gribberish = { path = "../gribberish", version = "1.0.1" }
 numpy = "0.27.0"

--- a/python/src/dataset.rs
+++ b/python/src/dataset.rs
@@ -1107,7 +1107,9 @@ fn build_group<'py>(
 
         // Link the variable to the scalar `spatial_ref` grid-mapping coordinate.
         if has_grid_mapping {
-            var_metadata.set_item("grid_mapping", "spatial_ref").unwrap();
+            var_metadata
+                .set_item("grid_mapping", "spatial_ref")
+                .unwrap();
         }
 
         let mut filtered = false;

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gribberish-types"
-version = "1.0.0"
+version = "1.0.1"
 authors = ["Matthew Iannucci <mpiannucci@gmail.com>"]
 description = "Common types for the gribberish crate"
 edition = "2021"


### PR DESCRIPTION
## Summary
- Bump all gribberish crates (`types`, `macros`, `gribberish`, `python`, `js`) and the npm package from `1.0.0` → `1.0.1` in lockstep, regenerating `Cargo.lock`.
- Add the `bump-version` skill (`bump_version.py` + `SKILL.md`) that drives the lockstep version bump across all manifests and regenerates the lockfile.

## Notes
- Version bump performed via the bundled `bump_version.py` driver — expected footprint of 7 files (6 manifests + `Cargo.lock`).
- No tagging, publishing, or wheel/npm release is performed here; that remains a separate step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)