### PR TITLE
Return zarr-python NDBuffer from GribberishCodec to match Codec spec and support codec pipelines

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -156,10 +156,10 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - name: Install package and test dependencies
         working-directory: python
-        run: pip install '.[xarray]' pytest
+        run: pip install '.[xarray,zarr]' pytest pytest-asyncio
       - name: Run tests
         working-directory: python
-        run: pytest tests/test_xarray_backend.py -v
+        run: pytest tests/test_xarray_backend.py tests/test_zarr_codec.py -v
 
   sdist:
     runs-on: ubuntu-latest

--- a/python/gribberish/zarr/codec.py
+++ b/python/gribberish/zarr/codec.py
@@ -52,7 +52,7 @@ class GribberishCodec(ArrayBytesCodec):
         if data.shape != chunk_spec.shape:
             data = data.reshape(chunk_spec.shape)
 
-        return data
+        return chunk_spec.prototype.nd_buffer.from_ndarray_like(data)
 
     async def _encode_single(
         self,

--- a/python/tests/test_zarr_codec.py
+++ b/python/tests/test_zarr_codec.py
@@ -21,7 +21,7 @@ async def test_decode_data_var_gribberish(dtype_str):
 
     buffer = default_buffer_prototype().buffer.from_bytes(raw_data)
     codec = GribberishCodec(var="UGRD")
-    data = await codec._decode_single(
+    decoded = await codec._decode_single(
         buffer,
         ArraySpec(
             shape=(1059, 1799),
@@ -31,6 +31,7 @@ async def test_decode_data_var_gribberish(dtype_str):
             config=ArrayConfig(order="C", write_empty_chunks=False),
         ),
     )
+    data = decoded.as_ndarray_like()
 
     assert data.shape == (1059, 1799)
     assert data.dtype == np.dtype(dtype_str)

--- a/python/tests/test_zarr_codec.py
+++ b/python/tests/test_zarr_codec.py
@@ -38,3 +38,33 @@ async def test_decode_data_var_gribberish(dtype_str):
         np.testing.assert_almost_equal(data[0][1000], -4.46501350402832),
         "Data not decoded correctly",
     )
+
+async def test_decode_chained_array_array_codec():
+    """Test an array -> array codec (filter) chained after GribberishCodec"""
+    from zarr.core.buffer import default_buffer_prototype
+
+    from gribberish import parse_grib_array
+    from gribberish.zarr.codec import GribberishCodec
+
+    with open("./../test-data/hrrr.t06z.wrfsfcf01-TMP.grib2", "rb") as f:
+        raw_data = f.read()
+
+    store = zarr.storage.MemoryStore()
+    array = zarr.create_array(
+        store,
+        name="tmp",
+        shape=(1059, 1799),
+        chunks=(1059, 1799),
+        dtype="float64",
+        fill_value=float("nan"),
+        compressors=(),
+        # decode order: serializer (GRIB bytes -> Kelvin), then filter (Kelvin -> Celsius)
+        filters=[zarr.codecs.ScaleOffset(offset=-273.15, scale=1)],
+        serializer=GribberishCodec(var="TMP"),
+    )
+    await store.set("tmp/c/0/0", default_buffer_prototype().buffer.from_bytes(raw_data))
+
+    data = array[:]
+
+    kelvin = parse_grib_array(raw_data, 0).reshape(1059, 1799)
+    np.testing.assert_allclose(data, kelvin - 273.15)


### PR DESCRIPTION
zarr-python's codec pipeline requires ArrayBytesCodec decode to return an NDBuffer. Currently, GribberishCodec returns a bare ndarray, so any array to array codec (aka filter) chained after it (e.g. ScaleOffset) fails with AttributeError.

Wrap the codec's return in a NDBuffer and add a test.