### PR TITLE
Add 0...360 -> -180...+180 longitude wrapping option

### DIFF
--- a/gribberish/src/lib.rs
+++ b/gribberish/src/lib.rs
@@ -8,3 +8,7 @@ pub mod message;
 pub mod message_metadata;
 pub mod sections;
 pub mod templates;
+
+// The longitude wrap kernel lives in the (private) `utils` tree; re-export the
+// one entry point bindings need so they don't reach through private modules.
+pub use utils::iter::projection::adjust_longitude_values;

--- a/gribberish/src/lib.rs
+++ b/gribberish/src/lib.rs
@@ -9,6 +9,4 @@ pub mod message_metadata;
 pub mod sections;
 pub mod templates;
 
-// The longitude wrap kernel lives in the (private) `utils` tree; re-export the
-// one entry point bindings need so they don't reach through private modules.
 pub use utils::iter::projection::adjust_longitude_values;

--- a/gribberish/src/message_metadata.rs
+++ b/gribberish/src/message_metadata.rs
@@ -65,6 +65,13 @@ impl MessageMetadata {
         self.projector.lat_lng()
     }
 
+    /// `latlng`, but when `adjust` is set the longitudes are wrapped to
+    /// `[-180, 180)` and made monotonic for eligible global grids. See
+    /// [`LatLngProjection::lat_lng_adjusted`].
+    pub fn latlng_adjusted(&self, adjust: bool) -> (Vec<f64>, Vec<f64>) {
+        self.projector.lat_lng_adjusted(adjust)
+    }
+
     pub fn xy(&self) -> (Vec<f64>, Vec<f64>) {
         (self.projector.x(), self.projector.y())
     }

--- a/gribberish/src/utils/iter/projection.rs
+++ b/gribberish/src/utils/iter/projection.rs
@@ -87,39 +87,13 @@ impl LatLngProjection {
     /// antimeridian from the east (the most-negative wrapped longitude); for a
     /// grid that already starts at 180° this is `0` (relabel only, no data move).
     pub fn longitude_wrap_roll(&self) -> Option<usize> {
-        let projection = match self {
-            LatLngProjection::PlateCaree(projection) => projection,
-            LatLngProjection::LambertConformal(_) => return None,
-        };
-
-        let nx = projection.longitudes.count;
-        let dx = projection.longitudes.step;
-        // Regular ascending grid only; descending-longitude grids are out of scope.
-        if nx == 0 || dx <= 0.0 {
-            return None;
+        match self {
+            // For a regular grid `lat_lng().1` is the 1-D longitude axis; for a
+            // projected grid it is the full flattened field, which is never
+            // eligible, so short-circuit it.
+            LatLngProjection::PlateCaree(_) => wrap_roll(&self.lat_lng().1),
+            LatLngProjection::LambertConformal(_) => None,
         }
-        // Near-global: the columns must densely cover ~360°, within a quarter cell
-        // (GDAL's tolerance). Excludes regional subsets and overlapping/duplicated
-        // wrap-around columns (e.g. a grid carrying both 0° and 360°).
-        if (dx * nx as f64 - 360.0).abs() >= dx / 4.0 {
-            return None;
-        }
-
-        // Rotate so the column with the most-negative wrapped longitude (closest
-        // to -180 from above) leads, which makes the wrapped axis monotonic.
-        let lngs = self.lat_lng().1;
-        let (roll, _) = lngs.iter().enumerate().fold(
-            (0usize, f64::INFINITY),
-            |(roll, min), (i, &lon)| {
-                let wrapped = wrap_longitude(lon);
-                if wrapped < min {
-                    (i, wrapped)
-                } else {
-                    (roll, min)
-                }
-            },
-        );
-        Some(roll)
     }
 
     /// Like [`lat_lng`](Self::lat_lng), but when `adjust` is set and the grid is
@@ -132,13 +106,7 @@ impl LatLngProjection {
         if !adjust {
             return (lats, lngs);
         }
-        match self.longitude_wrap_roll() {
-            Some(roll) => {
-                let wrapped: Vec<f64> = lngs.iter().map(|&lon| wrap_longitude(lon)).collect();
-                (lats, rotate_left(&wrapped, roll))
-            }
-            None => (lats, lngs),
-        }
+        (lats, adjust_longitude_values(lngs))
     }
 
     /// Apply the same longitude wrap as [`lat_lng_adjusted`](Self::lat_lng_adjusted)
@@ -309,6 +277,65 @@ fn wrap_longitude(lon: f64) -> f64 {
     }
 }
 
+/// For an ascending, near-global `[0, 360)` longitude axis, the number of
+/// columns to rotate left so the wrapped `[-180, 180)` axis is monotonic.
+///
+/// Returns `None` (callers should no-op) unless the axis spans ~360° with an
+/// ascending step — mirroring the conditions under which GDAL's
+/// `GRIB_ADJUST_LONGITUDE_RANGE` "split & swap" applies. The roll is the index
+/// of the column nearest the antimeridian from the east (the most-negative
+/// wrapped longitude); a grid that already starts at 180° rolls by `0` (relabel
+/// only, no data move). The step is read off the first two samples, so this
+/// works on either a projector's longitude axis or an already-materialized
+/// longitude coordinate.
+fn wrap_roll(lons: &[f64]) -> Option<usize> {
+    let nx = lons.len();
+    if nx < 2 {
+        return None;
+    }
+    // Regular ascending grid only; descending-longitude grids are out of scope.
+    let dx = lons[1] - lons[0];
+    if dx <= 0.0 {
+        return None;
+    }
+    // Near-global: the columns must densely cover ~360°, within a quarter cell
+    // (GDAL's tolerance). Excludes regional subsets and overlapping/duplicated
+    // wrap-around columns (e.g. a grid carrying both 0° and 360°).
+    if (dx * nx as f64 - 360.0).abs() >= dx / 4.0 {
+        return None;
+    }
+
+    // Rotate so the column with the most-negative wrapped longitude (closest to
+    // -180 from above) leads, which makes the wrapped axis monotonic.
+    let (roll, _) =
+        lons.iter()
+            .enumerate()
+            .fold((0usize, f64::INFINITY), |(roll, min), (i, &lon)| {
+                let wrapped = wrap_longitude(lon);
+                if wrapped < min {
+                    (i, wrapped)
+                } else {
+                    (roll, min)
+                }
+            });
+    Some(roll)
+}
+
+/// Wrap and rotate a `[0, 360)` longitude coordinate axis to a monotonic
+/// `[-180, 180)` range, returning it unchanged for axes that aren't eligible
+/// near-global ascending grids (see [`wrap_roll`]). The matching data buffer
+/// must be rolled with [`LatLngProjection::adjust_data_longitude`] so the
+/// coordinate and the data stay aligned.
+pub fn adjust_longitude_values(longitudes: Vec<f64>) -> Vec<f64> {
+    match wrap_roll(&longitudes) {
+        Some(roll) => {
+            let wrapped: Vec<f64> = longitudes.iter().map(|&lon| wrap_longitude(lon)).collect();
+            rotate_left(&wrapped, roll)
+        }
+        None => longitudes,
+    }
+}
+
 /// Rotate a slice left by `roll` positions: `out[i] = values[(i + roll) % n]`.
 fn rotate_left(values: &[f64], roll: usize) -> Vec<f64> {
     let n = values.len();
@@ -439,7 +466,10 @@ mod tests {
         // ECMWF grid that already starts at 180°: relabel only, no data move.
         assert_eq!(platecaree(180.0, 0.25, 1440).longitude_wrap_roll(), Some(0));
         // Grid already in [-180, 180): nothing to roll.
-        assert_eq!(platecaree(-180.0, 0.25, 1440).longitude_wrap_roll(), Some(0));
+        assert_eq!(
+            platecaree(-180.0, 0.25, 1440).longitude_wrap_roll(),
+            Some(0)
+        );
     }
 
     #[test]

--- a/gribberish/src/utils/iter/projection.rs
+++ b/gribberish/src/utils/iter/projection.rs
@@ -76,6 +76,90 @@ impl LatLngProjection {
         }
     }
 
+    /// For an eligible global grid, the number of columns to rotate the data and
+    /// longitude coordinates left so that longitudes run monotonically over
+    /// `[-180, 180)` instead of `[0, 360)`.
+    ///
+    /// Returns `None` (callers should no-op) unless the grid is a regular lat/lon
+    /// (`PlateCaree`) grid that spans ~360° with an ascending longitude axis —
+    /// mirroring the conditions under which GDAL's `GRIB_ADJUST_LONGITUDE_RANGE`
+    /// "split & swap" applies. The roll is the index of the column nearest the
+    /// antimeridian from the east (the most-negative wrapped longitude); for a
+    /// grid that already starts at 180° this is `0` (relabel only, no data move).
+    pub fn longitude_wrap_roll(&self) -> Option<usize> {
+        let projection = match self {
+            LatLngProjection::PlateCaree(projection) => projection,
+            LatLngProjection::LambertConformal(_) => return None,
+        };
+
+        let nx = projection.longitudes.count;
+        let dx = projection.longitudes.step;
+        // Regular ascending grid only; descending-longitude grids are out of scope.
+        if nx == 0 || dx <= 0.0 {
+            return None;
+        }
+        // Near-global: the columns must densely cover ~360°, within a quarter cell
+        // (GDAL's tolerance). Excludes regional subsets and overlapping/duplicated
+        // wrap-around columns (e.g. a grid carrying both 0° and 360°).
+        if (dx * nx as f64 - 360.0).abs() >= dx / 4.0 {
+            return None;
+        }
+
+        // Rotate so the column with the most-negative wrapped longitude (closest
+        // to -180 from above) leads, which makes the wrapped axis monotonic.
+        let lngs = self.lat_lng().1;
+        let (roll, _) = lngs.iter().enumerate().fold(
+            (0usize, f64::INFINITY),
+            |(roll, min), (i, &lon)| {
+                let wrapped = wrap_longitude(lon);
+                if wrapped < min {
+                    (i, wrapped)
+                } else {
+                    (roll, min)
+                }
+            },
+        );
+        Some(roll)
+    }
+
+    /// Like [`lat_lng`](Self::lat_lng), but when `adjust` is set and the grid is
+    /// eligible (see [`longitude_wrap_roll`](Self::longitude_wrap_roll)) the
+    /// longitudes are wrapped to `[-180, 180)` and rotated so they are
+    /// monotonically increasing. Latitudes are unchanged. A no-op (identical to
+    /// `lat_lng`) when `adjust` is false or the grid is not eligible.
+    pub fn lat_lng_adjusted(&self, adjust: bool) -> (Vec<f64>, Vec<f64>) {
+        let (lats, lngs) = self.lat_lng();
+        if !adjust {
+            return (lats, lngs);
+        }
+        match self.longitude_wrap_roll() {
+            Some(roll) => {
+                let wrapped: Vec<f64> = lngs.iter().map(|&lon| wrap_longitude(lon)).collect();
+                (lats, rotate_left(&wrapped, roll))
+            }
+            None => (lats, lngs),
+        }
+    }
+
+    /// Apply the same longitude wrap as [`lat_lng_adjusted`](Self::lat_lng_adjusted)
+    /// to a decoded data buffer laid out row-major as `ny × nx` (latitude-major,
+    /// longitude fastest), rolling its columns so it stays aligned with the
+    /// wrapped longitude coordinates. A no-op when `adjust` is false or the grid
+    /// is not eligible.
+    pub fn adjust_data_longitude(&self, data: Vec<f64>, adjust: bool) -> Vec<f64> {
+        if !adjust {
+            return data;
+        }
+        match (self, self.longitude_wrap_roll()) {
+            (LatLngProjection::PlateCaree(projection), Some(roll)) => {
+                let nx = projection.longitudes.count;
+                let ny = projection.latitudes.count;
+                rotate_rows_left(&data, ny, nx, roll)
+            }
+            _ => data,
+        }
+    }
+
     pub fn x(&self) -> Vec<f64> {
         match self {
             LatLngProjection::PlateCaree(projection) => {
@@ -213,6 +297,47 @@ impl Iterator for RegularCoordinateIterator {
     }
 }
 
+/// Wrap a longitude given in `[0, 360)` into `[-180, 180)`. The antimeridian
+/// (exactly 180°) maps to -180, yielding a clean half-open range — matching
+/// `(lon + 180) % 360 - 180` rather than GDAL's `if (lon == 180) return 180`
+/// special-case, which only matters for a scalar geotransform origin.
+fn wrap_longitude(lon: f64) -> f64 {
+    if lon >= 180.0 {
+        lon - 360.0
+    } else {
+        lon
+    }
+}
+
+/// Rotate a slice left by `roll` positions: `out[i] = values[(i + roll) % n]`.
+fn rotate_left(values: &[f64], roll: usize) -> Vec<f64> {
+    let n = values.len();
+    if n == 0 || roll.is_multiple_of(n) {
+        return values.to_vec();
+    }
+    let roll = roll % n;
+    (0..n).map(|i| values[(i + roll) % n]).collect()
+}
+
+/// Rotate each row of a row-major `ny × nx` buffer left by `roll` columns. Used
+/// to apply a longitude wrap to decoded data so it stays aligned with the
+/// wrapped longitude coordinates. Returns the input unchanged if `roll` is a
+/// no-op or the dimensions don't match the buffer length.
+pub fn rotate_rows_left(data: &[f64], ny: usize, nx: usize, roll: usize) -> Vec<f64> {
+    if nx == 0 || roll.is_multiple_of(nx) || ny * nx != data.len() {
+        return data.to_vec();
+    }
+    let roll = roll % nx;
+    let mut out = vec![0.0; data.len()];
+    for r in 0..ny {
+        let row = &data[r * nx..(r + 1) * nx];
+        for c in 0..nx {
+            out[r * nx + c] = row[(c + roll) % nx];
+        }
+    }
+    out
+}
+
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
@@ -290,5 +415,92 @@ mod tests {
                 lng
             );
         }
+    }
+
+    fn platecaree(lon_start: f64, lon_step: f64, lon_count: usize) -> super::LatLngProjection {
+        let latitudes = super::RegularCoordinateIterator::new(90.0, -1.0, 5);
+        let longitudes = super::RegularCoordinateIterator::new(lon_start, lon_step, lon_count);
+        super::LatLngProjection::PlateCaree(crate::utils::iter::projection::PlateCareeProjection {
+            latitudes,
+            longitudes,
+            projection_name: "latlon".into(),
+            projection_params: HashMap::new(),
+        })
+    }
+
+    #[test]
+    fn test_longitude_wrap_roll() {
+        // GFS 0.25°: 1440 columns, split at 180° -> column 720.
+        assert_eq!(platecaree(0.0, 0.25, 1440).longitude_wrap_roll(), Some(720));
+        // GEFS 0.5°: 720 columns -> column 360.
+        assert_eq!(platecaree(0.0, 0.5, 720).longitude_wrap_roll(), Some(360));
+        // ERA5-style 3° GRIB: 120 columns, 180° at column 60.
+        assert_eq!(platecaree(0.0, 3.0, 120).longitude_wrap_roll(), Some(60));
+        // ECMWF grid that already starts at 180°: relabel only, no data move.
+        assert_eq!(platecaree(180.0, 0.25, 1440).longitude_wrap_roll(), Some(0));
+        // Grid already in [-180, 180): nothing to roll.
+        assert_eq!(platecaree(-180.0, 0.25, 1440).longitude_wrap_roll(), Some(0));
+    }
+
+    #[test]
+    fn test_longitude_wrap_roll_ineligible() {
+        // Regional subset (90° wide) is not global -> None.
+        assert_eq!(platecaree(0.0, 0.25, 360).longitude_wrap_roll(), None);
+        // Descending longitude axis is out of scope -> None.
+        assert_eq!(platecaree(359.75, -0.25, 1440).longitude_wrap_roll(), None);
+        // Overlapping wrap-around (carries both 0° and 360°) -> None.
+        assert_eq!(platecaree(0.0, 0.25, 1441).longitude_wrap_roll(), None);
+    }
+
+    #[test]
+    fn test_lat_lng_adjusted_monotonic() {
+        let projection = platecaree(0.0, 0.5, 720);
+        let (_, native) = projection.lat_lng();
+        let (lats, lngs) = projection.lat_lng_adjusted(true);
+
+        // Latitudes are untouched.
+        assert_eq!(lats, projection.lat_lng().0);
+
+        // Strictly monotonic increasing over [-180, 180).
+        assert_eq!(lngs.len(), 720);
+        assert!((lngs[0] - (-180.0)).abs() < f64::EPSILON);
+        assert!((lngs[719] - 179.5).abs() < f64::EPSILON);
+        for w in lngs.windows(2) {
+            assert!(w[1] > w[0], "not monotonic at {} -> {}", w[0], w[1]);
+        }
+        for &lng in &lngs {
+            assert!((-180.0..180.0).contains(&lng), "out of range: {lng}");
+        }
+
+        // No data lost: the wrapped set matches wrapping each native value.
+        let mut from_native: Vec<f64> = native.iter().map(|&l| super::wrap_longitude(l)).collect();
+        let mut adjusted = lngs.clone();
+        from_native.sort_by(|a, b| a.partial_cmp(b).unwrap());
+        adjusted.sort_by(|a, b| a.partial_cmp(b).unwrap());
+        assert_eq!(from_native, adjusted);
+    }
+
+    #[test]
+    fn test_lat_lng_adjusted_noop_when_disabled_or_ineligible() {
+        let global = platecaree(0.0, 0.5, 720);
+        assert_eq!(global.lat_lng_adjusted(false), global.lat_lng());
+
+        let regional = platecaree(0.0, 0.25, 360);
+        assert_eq!(regional.lat_lng_adjusted(true), regional.lat_lng());
+    }
+
+    #[test]
+    fn test_rotate_rows_left() {
+        // 2 rows x 4 cols, roll left by 1.
+        let data = vec![0.0, 1.0, 2.0, 3.0, 10.0, 11.0, 12.0, 13.0];
+        let rolled = super::rotate_rows_left(&data, 2, 4, 1);
+        assert_eq!(rolled, vec![1.0, 2.0, 3.0, 0.0, 11.0, 12.0, 13.0, 10.0]);
+
+        // roll == 0 and roll == nx are no-ops.
+        assert_eq!(super::rotate_rows_left(&data, 2, 4, 0), data);
+        assert_eq!(super::rotate_rows_left(&data, 2, 4, 4), data);
+
+        // Mismatched dimensions return the input unchanged.
+        assert_eq!(super::rotate_rows_left(&data, 3, 4, 1), data);
     }
 }

--- a/gribberish/src/utils/iter/projection.rs
+++ b/gribberish/src/utils/iter/projection.rs
@@ -273,13 +273,14 @@ fn wrap_longitude(lon: f64) -> f64 {
 /// columns to rotate left so the wrapped `[-180, 180)` axis is monotonic.
 ///
 /// Returns `None` (callers should no-op) unless the axis spans ~360° with an
-/// ascending step — mirroring the conditions under which GDAL's
-/// `GRIB_ADJUST_LONGITUDE_RANGE` "split & swap" applies. The roll is the index
-/// of the column nearest the antimeridian from the east (the most-negative
-/// wrapped longitude); a grid that already starts at 180° rolls by `0` (relabel
-/// only, no data move). The step is read off the first two samples, so this
-/// works on either a projector's longitude axis or an already-materialized
-/// longitude coordinate.
+/// ascending step. The roll is the index of the column nearest the antimeridian
+/// from the east (the most-negative wrapped longitude); a grid that already
+/// starts at 180° rolls by `0` (relabel only, no data move). The step is read
+/// off the first two samples, so this works on either a projector's longitude
+/// axis or an already-materialized longitude coordinate.
+///
+/// The logic to determine whether this should be applied mirrors GDAL's
+/// `GRIB_ADJUST_LONGITUDE_RANGE` "split & swap" option.
 fn wrap_roll(lons: &[f64]) -> Option<usize> {
     let nx = lons.len();
     if nx < 2 {

--- a/gribberish/src/utils/iter/projection.rs
+++ b/gribberish/src/utils/iter/projection.rs
@@ -260,9 +260,7 @@ impl Iterator for RegularCoordinateIterator {
 }
 
 /// Wrap a longitude given in `[0, 360)` into `[-180, 180)`. The antimeridian
-/// (exactly 180°) maps to -180, yielding a clean half-open range — matching
-/// `(lon + 180) % 360 - 180` rather than GDAL's `if (lon == 180) return 180`
-/// special-case, which only matters for a scalar geotransform origin.
+/// (exactly 180°) maps to -180.
 fn wrap_longitude(lon: f64) -> f64 {
     if lon >= 180.0 {
         lon - 360.0

--- a/gribberish/src/utils/iter/projection.rs
+++ b/gribberish/src/utils/iter/projection.rs
@@ -76,17 +76,11 @@ impl LatLngProjection {
         }
     }
 
-    /// For an eligible global grid, the number of columns to rotate the data and
-    /// longitude coordinates left so that longitudes run monotonically over
-    /// `[-180, 180)` instead of `[0, 360)`.
-    ///
-    /// Returns `None` (callers should no-op) unless the grid is a regular lat/lon
-    /// (`PlateCaree`) grid that spans ~360° with an ascending longitude axis —
-    /// mirroring the conditions under which GDAL's `GRIB_ADJUST_LONGITUDE_RANGE`
-    /// "split & swap" applies. The roll is the index of the column nearest the
-    /// antimeridian from the east (the most-negative wrapped longitude); for a
-    /// grid that already starts at 180° this is `0` (relabel only, no data move).
-    pub fn longitude_wrap_roll(&self) -> Option<usize> {
+    /// Columns to roll this projection's longitude axis (and matching data) left
+    /// so longitudes run monotonically over `[-180, 180)`, or `None` for
+    /// projected/ineligible grids (callers no-op). See [`wrap_roll`] for the
+    /// eligibility rules and how the roll is chosen.
+    fn longitude_wrap_roll(&self) -> Option<usize> {
         match self {
             // For a regular grid `lat_lng().1` is the 1-D longitude axis; for a
             // projected grid it is the full flattened field, which is never
@@ -96,11 +90,11 @@ impl LatLngProjection {
         }
     }
 
-    /// Like [`lat_lng`](Self::lat_lng), but when `adjust` is set and the grid is
-    /// eligible (see [`longitude_wrap_roll`](Self::longitude_wrap_roll)) the
-    /// longitudes are wrapped to `[-180, 180)` and rotated so they are
-    /// monotonically increasing. Latitudes are unchanged. A no-op (identical to
-    /// `lat_lng`) when `adjust` is false or the grid is not eligible.
+    /// Like [`lat_lng`](Self::lat_lng), but when `adjust` is set the longitudes
+    /// are wrapped to `[-180, 180)` and rotated so they are monotonically
+    /// increasing (see [`adjust_longitude_values`]). Latitudes are unchanged. A
+    /// no-op (identical to `lat_lng`) when `adjust` is false or the grid is not
+    /// eligible.
     pub fn lat_lng_adjusted(&self, adjust: bool) -> (Vec<f64>, Vec<f64>) {
         let (lats, lngs) = self.lat_lng();
         if !adjust {
@@ -350,7 +344,7 @@ fn rotate_left(values: &[f64], roll: usize) -> Vec<f64> {
 /// to apply a longitude wrap to decoded data so it stays aligned with the
 /// wrapped longitude coordinates. Returns the input unchanged if `roll` is a
 /// no-op or the dimensions don't match the buffer length.
-pub fn rotate_rows_left(data: &[f64], ny: usize, nx: usize, roll: usize) -> Vec<f64> {
+fn rotate_rows_left(data: &[f64], ny: usize, nx: usize, roll: usize) -> Vec<f64> {
     if nx == 0 || roll.is_multiple_of(nx) || ny * nx != data.len() {
         return data.to_vec();
     }
@@ -508,6 +502,30 @@ mod tests {
         from_native.sort_by(|a, b| a.partial_cmp(b).unwrap());
         adjusted.sort_by(|a, b| a.partial_cmp(b).unwrap());
         assert_eq!(from_native, adjusted);
+    }
+
+    #[test]
+    fn test_longitude_wrap_off_column_split() {
+        // Cell-centered 1° grid (0.5, 1.5, ... 359.5): 180° falls *between*
+        // columns, so the split must land on the most-negative wrapped column
+        // (180.5 -> -179.5 at index 180), not on an exact 180° column.
+        let projection = platecaree(0.5, 1.0, 360);
+        assert_eq!(projection.longitude_wrap_roll(), Some(180));
+
+        let (_, lngs) = projection.lat_lng_adjusted(true);
+        assert_eq!(lngs.len(), 360);
+        assert!((lngs[0] - (-179.5)).abs() < f64::EPSILON);
+        assert!((lngs[359] - 179.5).abs() < f64::EPSILON);
+        for w in lngs.windows(2) {
+            assert!(w[1] > w[0], "not monotonic at {} -> {}", w[0], w[1]);
+        }
+        for &lng in &lngs {
+            assert!((-180.0..180.0).contains(&lng), "out of range: {lng}");
+        }
+
+        // Idempotent: wrapping an already-monotonic [-180, 180) axis is a no-op
+        // (its roll is 0).
+        assert_eq!(super::adjust_longitude_values(lngs.clone()), lngs);
     }
 
     #[test]

--- a/gribberish/tests/read.rs
+++ b/gribberish/tests/read.rs
@@ -700,9 +700,18 @@ fn test_longitude_adjustment_geavg() {
     // Latitudes untouched; longitudes wrapped, monotonic, in [-180, 180).
     assert_eq!(lats, projector.lat_lng().0);
     assert_eq!(lngs.len(), 720);
-    assert!((lngs[0] - (-180.0)).abs() < 0.001, "first lng should be -180");
-    assert!((lngs[360] - 0.0).abs() < 0.001, "lng at index 360 should be 0");
-    assert!((lngs[719] - 179.5).abs() < 0.001, "last lng should be 179.5");
+    assert!(
+        (lngs[0] - (-180.0)).abs() < 0.001,
+        "first lng should be -180"
+    );
+    assert!(
+        (lngs[360] - 0.0).abs() < 0.001,
+        "lng at index 360 should be 0"
+    );
+    assert!(
+        (lngs[719] - 179.5).abs() < 0.001,
+        "last lng should be 179.5"
+    );
     for i in 1..lngs.len() {
         assert!(lngs[i] > lngs[i - 1], "longitudes must be monotonic");
         assert!((-180.0..180.0).contains(&lngs[i]), "lng out of range");
@@ -721,7 +730,10 @@ fn test_longitude_adjustment_geavg() {
 
     // Disabled / no-op path returns the originals unchanged.
     assert_eq!(projector.lat_lng_adjusted(false), projector.lat_lng());
-    assert_eq!(projector.adjust_data_longitude(native.clone(), false), native);
+    assert_eq!(
+        projector.adjust_data_longitude(native.clone(), false),
+        native
+    );
 }
 
 #[test]
@@ -734,8 +746,14 @@ fn test_longitude_adjustment_era5_grib1() {
 
     let (_, lngs) = projector.lat_lng_adjusted(true);
     assert_eq!(lngs.len(), 120);
-    assert!((lngs[0] - (-180.0)).abs() < 0.001, "first lng should be -180");
-    assert!((lngs[60] - 0.0).abs() < 0.001, "lng at index 60 should be 0");
+    assert!(
+        (lngs[0] - (-180.0)).abs() < 0.001,
+        "first lng should be -180"
+    );
+    assert!(
+        (lngs[60] - 0.0).abs() < 0.001,
+        "lng at index 60 should be 0"
+    );
     assert!((lngs[119] - 177.0).abs() < 0.001, "last lng should be 177");
     for i in 1..lngs.len() {
         assert!(lngs[i] > lngs[i - 1], "longitudes must be monotonic");
@@ -746,7 +764,11 @@ fn test_longitude_adjustment_era5_grib1() {
     let nx = 120usize;
     for (i, value) in adjusted.iter().enumerate() {
         let (row, col) = (i / nx, i % nx);
-        assert_eq!(*value, native[row * nx + (col + 60) % nx], "roll mismatch at {i}");
+        assert_eq!(
+            *value,
+            native[row * nx + (col + 60) % nx],
+            "roll mismatch at {i}"
+        );
     }
 }
 

--- a/gribberish/tests/read.rs
+++ b/gribberish/tests/read.rs
@@ -688,6 +688,69 @@ fn read_nbm_lambert_specified_radius_projection() {
 }
 
 #[test]
+fn test_longitude_adjustment_geavg() {
+    // GEFS 0.5° global grid (0..359.5): opt-in wrap to -180..180.
+    let grib_data = read_grib_messages("../test-data/geavg.t12z.pgrb2a.0p50.f000");
+    let messages = read_messages(grib_data.as_slice()).collect::<Vec<Message>>();
+    let msg = &messages[0];
+    let projector = msg.latlng_projector().expect("Failed to get projector");
+
+    let (lats, lngs) = projector.lat_lng_adjusted(true);
+
+    // Latitudes untouched; longitudes wrapped, monotonic, in [-180, 180).
+    assert_eq!(lats, projector.lat_lng().0);
+    assert_eq!(lngs.len(), 720);
+    assert!((lngs[0] - (-180.0)).abs() < 0.001, "first lng should be -180");
+    assert!((lngs[360] - 0.0).abs() < 0.001, "lng at index 360 should be 0");
+    assert!((lngs[719] - 179.5).abs() < 0.001, "last lng should be 179.5");
+    for i in 1..lngs.len() {
+        assert!(lngs[i] > lngs[i - 1], "longitudes must be monotonic");
+        assert!((-180.0..180.0).contains(&lngs[i]), "lng out of range");
+    }
+
+    // Data is rolled by the same amount (360) so it stays aligned with coords.
+    let native = msg.data().expect("Failed to decode data");
+    let adjusted = projector.adjust_data_longitude(native.clone(), true);
+    assert_eq!(adjusted.len(), native.len());
+    let nx = 720usize;
+    for (i, value) in adjusted.iter().enumerate() {
+        let (row, col) = (i / nx, i % nx);
+        let expected = native[row * nx + (col + 360) % nx];
+        assert_eq!(*value, expected, "data not rolled correctly at {i}");
+    }
+
+    // Disabled / no-op path returns the originals unchanged.
+    assert_eq!(projector.lat_lng_adjusted(false), projector.lat_lng());
+    assert_eq!(projector.adjust_data_longitude(native.clone(), false), native);
+}
+
+#[test]
+fn test_longitude_adjustment_era5_grib1() {
+    // ERA5 GRIB1 3° global grid (0..357): wrap to -180..180, roll 60.
+    let grib_data = read_grib_messages("../test-data/era5-levels-members.grib");
+    let messages = read_messages(grib_data.as_slice()).collect::<Vec<Message>>();
+    let msg = &messages[0];
+    let projector = msg.latlng_projector().expect("Failed to get projector");
+
+    let (_, lngs) = projector.lat_lng_adjusted(true);
+    assert_eq!(lngs.len(), 120);
+    assert!((lngs[0] - (-180.0)).abs() < 0.001, "first lng should be -180");
+    assert!((lngs[60] - 0.0).abs() < 0.001, "lng at index 60 should be 0");
+    assert!((lngs[119] - 177.0).abs() < 0.001, "last lng should be 177");
+    for i in 1..lngs.len() {
+        assert!(lngs[i] > lngs[i - 1], "longitudes must be monotonic");
+    }
+
+    let native = msg.data().expect("Failed to decode data");
+    let adjusted = projector.adjust_data_longitude(native.clone(), true);
+    let nx = 120usize;
+    for (i, value) in adjusted.iter().enumerate() {
+        let (row, col) = (i / nx, i % nx);
+        assert_eq!(*value, native[row * nx + (col + 60) % nx], "roll mismatch at {i}");
+    }
+}
+
+#[test]
 fn read_hrrr_hpbl_parameter() {
     // Test the new PlanetaryBoundaryLayerHeight (HPBL) meteorological parameter
     // disc=0 (meteorological), cat=3 (mass), num=18

--- a/python/gribberish/virtualizarr/parser.py
+++ b/python/gribberish/virtualizarr/parser.py
@@ -45,11 +45,18 @@ _BYTES_CODEC = {"name": "bytes", "configuration": {"endian": "little"}}
 _N_SPATIAL = 2
 
 
-def _gribberish_codecs(var: str) -> list[dict[str, Any]]:
-    return [{"name": _GRIBBERISH_CODEC, "configuration": {"var": var}}]
+def _gribberish_codecs(
+    var: str, adjust_longitude_range: bool = False
+) -> list[dict[str, Any]]:
+    configuration: dict[str, Any] = {"var": var}
+    if adjust_longitude_range:
+        configuration["adjust_longitude_range"] = True
+    return [{"name": _GRIBBERISH_CODEC, "configuration": configuration}]
 
 
-def _data_manifest_array(url: str, name: str, var: dict[str, Any]) -> ManifestArray:
+def _data_manifest_array(
+    url: str, name: str, var: dict[str, Any], adjust_longitude_range: bool = False
+) -> ManifestArray:
     """One ManifestArray per data variable; each GRIB message is one chunk."""
     dims = tuple(var["dims"])
     shape = tuple(int(s) for s in var["values"]["shape"])
@@ -88,7 +95,7 @@ def _data_manifest_array(url: str, name: str, var: dict[str, Any]) -> ManifestAr
         data_type=np.dtype("float64"),
         chunk_shape=chunk_shape,
         fill_value=float("nan"),
-        codecs=_gribberish_codecs(name),
+        codecs=_gribberish_codecs(name, adjust_longitude_range),
         attributes=dict(var["attrs"]),
         dimension_names=dims,
     )
@@ -96,7 +103,7 @@ def _data_manifest_array(url: str, name: str, var: dict[str, Any]) -> ManifestAr
 
 
 def _reference_coord_array(
-    url: str, name: str, coord: dict[str, Any]
+    url: str, name: str, coord: dict[str, Any], adjust_longitude_range: bool = False
 ) -> ManifestArray:
     """A coordinate stored as a byte range in the file (projected lat/lon)."""
     values = coord["values"]
@@ -117,7 +124,7 @@ def _reference_coord_array(
         data_type=np.dtype("float64"),
         chunk_shape=shape,
         fill_value=float("nan"),
-        codecs=_gribberish_codecs(name),
+        codecs=_gribberish_codecs(name, adjust_longitude_range),
         attributes=dict(coord["attrs"]),
         dimension_names=dims,
     )
@@ -171,26 +178,30 @@ def _inline_coord_array(name: str, coord: dict[str, Any]) -> ManifestArray:
     return ManifestArray(metadata=metadata, chunkmanifest=manifest)
 
 
-def _coord_manifest_array(url: str, name: str, coord: dict[str, Any]) -> ManifestArray:
+def _coord_manifest_array(
+    url: str, name: str, coord: dict[str, Any], adjust_longitude_range: bool = False
+) -> ManifestArray:
     if isinstance(coord["values"], dict):
-        return _reference_coord_array(url, name, coord)
+        return _reference_coord_array(url, name, coord, adjust_longitude_range)
     return _inline_coord_array(name, coord)
 
 
-def _manifest_group(url: str, node: dict[str, Any]) -> ManifestGroup:
+def _manifest_group(
+    url: str, node: dict[str, Any], adjust_longitude_range: bool = False
+) -> ManifestGroup:
     """Recursively build a ManifestGroup (and its subgroups) from a tree node."""
     arrays: dict[str, ManifestArray] = {}
     coord_names: list[str] = []
 
     for name, coord in node.get("coords", {}).items():
-        arrays[name] = _coord_manifest_array(url, name, coord)
+        arrays[name] = _coord_manifest_array(url, name, coord, adjust_longitude_range)
         coord_names.append(name)
 
     for name, var in node.get("data_vars", {}).items():
-        arrays[name] = _data_manifest_array(url, name, var)
+        arrays[name] = _data_manifest_array(url, name, var, adjust_longitude_range)
 
     groups = {
-        gname: _manifest_group(url, gnode)
+        gname: _manifest_group(url, gnode, adjust_longitude_range)
         for gname, gnode in node.get("groups", {}).items()
     }
 
@@ -230,6 +241,12 @@ class GribberishParser:
         the known index names and silently falls back to a full read when none
         is found; an explicit suffix (``".idx"``, ``".index"``, ``".inv"``,
         ...) probes only that name and raises when it is missing.
+    adjust_longitude_range
+        Rewrap global 0–360° longitude grids to a monotonic −180…180° range:
+        the emitted ``longitude`` coordinate is wrapped and every data variable's
+        codec is told to roll its decoded chunk along the longitude axis to
+        match, so the published store slices cleanly across the prime meridian.
+        Default off; a no-op for grids that don't span the globe.
     """
 
     def __init__(
@@ -240,6 +257,7 @@ class GribberishParser:
         filter_by_attrs: dict[str, Any] | None = None,
         filter_by_variable_attrs: dict[str, Any] | None = None,
         use_index: bool | str = False,
+        adjust_longitude_range: bool = False,
     ) -> None:
         self.drop_variables = drop_variables
         self.only_variables = only_variables
@@ -247,6 +265,7 @@ class GribberishParser:
         self.filter_by_attrs = filter_by_attrs
         self.filter_by_variable_attrs = filter_by_variable_attrs
         self.use_index = use_index
+        self.adjust_longitude_range = adjust_longitude_range
 
     def _filter_kwargs(self) -> dict[str, Any]:
         return dict(
@@ -257,6 +276,9 @@ class GribberishParser:
             filter_by_variable_attrs=self.filter_by_variable_attrs,
             # Keep projected lat/lon as references rather than materializing them.
             encode_coords=True,
+            # Wrap inlined regular-grid longitude coords to match the data roll
+            # the codec applies at read time.
+            adjust_longitude_range=self.adjust_longitude_range,
         )
 
     def _parse_via_index(self, store, path: str, entries) -> dict[str, Any]:
@@ -304,5 +326,5 @@ class GribberishParser:
             data = _read_all(store, path_in_store)
             dataset = parse_grib_dataset(data, **self._filter_kwargs())
 
-        group = _manifest_group(url, dataset)
+        group = _manifest_group(url, dataset, self.adjust_longitude_range)
         return ManifestStore(group, registry=registry)

--- a/python/gribberish/virtualizarr/parser.py
+++ b/python/gribberish/virtualizarr/parser.py
@@ -18,7 +18,11 @@ import numpy as np
 # is what decodes each chunk at read time (and is required for zarr to validate
 # the codec pipeline when the array metadata is constructed below).
 from gribberish.zarr.codec import GribberishCodec  # noqa: F401
-from gribberish import parse_grib_dataset, parse_grib_dataset_from_headers
+from gribberish import (
+    adjust_longitude_values,
+    parse_grib_dataset,
+    parse_grib_dataset_from_headers,
+)
 from gribberish._index import (
     HEADER_BYTES,
     fetch_index_entries,
@@ -103,7 +107,7 @@ def _data_manifest_array(
 
 
 def _reference_coord_array(
-    url: str, name: str, coord: dict[str, Any], adjust_longitude_range: bool = False
+    url: str, name: str, coord: dict[str, Any]
 ) -> ManifestArray:
     """A coordinate stored as a byte range in the file (projected lat/lon)."""
     values = coord["values"]
@@ -124,18 +128,26 @@ def _reference_coord_array(
         data_type=np.dtype("float64"),
         chunk_shape=shape,
         fill_value=float("nan"),
-        codecs=_gribberish_codecs(name, adjust_longitude_range),
+        codecs=_gribberish_codecs(name),
         attributes=dict(coord["attrs"]),
         dimension_names=dims,
     )
     return ManifestArray(metadata=metadata, chunkmanifest=manifest)
 
 
-def _inline_coord_array(name: str, coord: dict[str, Any]) -> ManifestArray:
+def _inline_coord_array(
+    name: str, coord: dict[str, Any], adjust_longitude_range: bool = False
+) -> ManifestArray:
     """A small derived coordinate (time/level/number/...) inlined as raw bytes."""
     dims = tuple(coord["dims"])
     attrs = dict(coord["attrs"])
     arr = np.asarray(coord["values"])
+
+    # Rewrap an inlined 0–360° longitude axis to a monotonic −180…180° range,
+    # matching the roll the codec applies to each data chunk at read time. A
+    # no-op for grids that don't span the globe (the kernel decides eligibility).
+    if adjust_longitude_range and name == "longitude":
+        arr = np.asarray(adjust_longitude_values(arr))
 
     if arr.dtype.kind == "M":
         # Store datetimes as CF-encoded int64 seconds so xarray can decode them.
@@ -182,8 +194,8 @@ def _coord_manifest_array(
     url: str, name: str, coord: dict[str, Any], adjust_longitude_range: bool = False
 ) -> ManifestArray:
     if isinstance(coord["values"], dict):
-        return _reference_coord_array(url, name, coord, adjust_longitude_range)
-    return _inline_coord_array(name, coord)
+        return _reference_coord_array(url, name, coord)
+    return _inline_coord_array(name, coord, adjust_longitude_range)
 
 
 def _manifest_group(
@@ -276,9 +288,6 @@ class GribberishParser:
             filter_by_variable_attrs=self.filter_by_variable_attrs,
             # Keep projected lat/lon as references rather than materializing them.
             encode_coords=True,
-            # Wrap inlined regular-grid longitude coords to match the data roll
-            # the codec applies at read time.
-            adjust_longitude_range=self.adjust_longitude_range,
         )
 
     def _parse_via_index(self, store, path: str, entries) -> dict[str, Any]:

--- a/python/gribberish/virtualizarr/parser.py
+++ b/python/gribberish/virtualizarr/parser.py
@@ -146,7 +146,9 @@ def _inline_coord_array(
     # Rewrap an inlined 0–360° longitude axis to a monotonic −180…180° range,
     # matching the roll the codec applies to each data chunk at read time. A
     # no-op for grids that don't span the globe (the kernel decides eligibility).
-    if adjust_longitude_range and name == "longitude":
+    # Only the 1-D regular-grid axis is wrapped; a projected grid's 2-D longitude
+    # is stored as a reference (not inlined), so the ndim guard is also future-proofing.
+    if adjust_longitude_range and name == "longitude" and arr.ndim == 1:
         arr = np.asarray(adjust_longitude_values(arr))
 
     if arr.dtype.kind == "M":

--- a/python/gribberish/virtualizarr/parser.py
+++ b/python/gribberish/virtualizarr/parser.py
@@ -145,7 +145,7 @@ def _inline_coord_array(
 
     # Rewrap an inlined 0–360° longitude axis to a monotonic −180…180° range,
     # matching the roll the codec applies to each data chunk at read time. A
-    # no-op for grids that don't span the globe (the kernel decides eligibility).
+    # no-op for grids that don't span the globe.
     # Only the 1-D regular-grid axis is wrapped; a projected grid's 2-D longitude
     # is stored as a reference (not inlined), so the ndim guard is also future-proofing.
     if adjust_longitude_range and name == "longitude" and arr.ndim == 1:

--- a/python/gribberish/zarr/codec.py
+++ b/python/gribberish/zarr/codec.py
@@ -11,12 +11,21 @@ from zarr.registry import register_codec
 
 @dataclass(frozen=True)
 class GribberishCodec(ArrayBytesCodec):
-    """Transform GRIB2 bytes into zarr arrays using gribberish library"""
+    """Transform GRIB2 bytes into zarr arrays using gribberish library
+
+    When ``adjust_longitude_range`` is set, global 0–360° longitude grids are
+    rewrapped to a monotonic −180…180° range: the decoded data is rolled along
+    the longitude axis and the ``longitude`` coordinate is wrapped to match, so
+    label-based slicing across the prime meridian behaves as expected. It is a
+    no-op for grids that don't span the globe.
+    """
 
     var: str | None
+    adjust_longitude_range: bool = False
 
-    def __init__(self, var: str | None) -> Self:
+    def __init__(self, var: str | None, adjust_longitude_range: bool = False) -> Self:
         object.__setattr__(self, "var", var)
+        object.__setattr__(self, "adjust_longitude_range", bool(adjust_longitude_range))
 
     @classmethod
     def from_dict(cls, data: dict[str, JSON]) -> Self:
@@ -27,10 +36,14 @@ class GribberishCodec(ArrayBytesCodec):
         return cls(**configuration_parsed)  # type: ignore[arg-type]
 
     def to_dict(self) -> dict[str, JSON]:
-        if not self.var:
+        configuration: dict[str, JSON] = {}
+        if self.var:
+            configuration["var"] = self.var
+        if self.adjust_longitude_range:
+            configuration["adjust_longitude_range"] = True
+        if not configuration:
             return {"name": "gribberish"}
-        else:
-            return {"name": "gribberish", "configuration": {"var": self.var}}
+        return {"name": "gribberish", "configuration": configuration}
 
     async def _decode_single(
         self,
@@ -42,10 +55,12 @@ class GribberishCodec(ArrayBytesCodec):
 
         if self.var == 'latitude' or self.var == 'longitude':
             message = parse_grib_message_metadata(chunk_bytes, 0)
-            lat, lng = message.latlng()
+            lat, lng = message.latlng(self.adjust_longitude_range)
             data: NDArrayLike = lat if self.var == 'latitude' else lng
         else:
-            data: NDArrayLike = parse_grib_array(chunk_bytes, 0)
+            data: NDArrayLike = parse_grib_array(
+                chunk_bytes, 0, self.adjust_longitude_range
+            )
 
         if (native_dtype := chunk_spec.dtype.to_native_dtype()) != data.dtype:
             data = data.astype(native_dtype)

--- a/python/src/dataset.rs
+++ b/python/src/dataset.rs
@@ -177,7 +177,7 @@ fn cf_grid_mapping<'py>(
 }
 
 #[pyfunction]
-#[pyo3(signature = (data, drop_variables=None, only_variables=None, perserve_dims=None, filter_by_attrs=None, filter_by_variable_attrs=None, encode_coords=None, adjust_longitude_range=None))]
+#[pyo3(signature = (data, drop_variables=None, only_variables=None, perserve_dims=None, filter_by_attrs=None, filter_by_variable_attrs=None, encode_coords=None))]
 #[allow(clippy::too_many_arguments)]
 pub fn parse_grib_dataset<'py>(
     py: Python<'py>,
@@ -188,7 +188,6 @@ pub fn parse_grib_dataset<'py>(
     filter_by_attrs: Option<&Bound<'py, PyDict>>,
     filter_by_variable_attrs: Option<&Bound<'py, PyDict>>,
     encode_coords: Option<bool>,
-    adjust_longitude_range: Option<bool>,
 ) -> PyResult<Bound<'py, PyDict>> {
     build_grib_dataset(
         py,
@@ -199,7 +198,6 @@ pub fn parse_grib_dataset<'py>(
         filter_by_attrs,
         filter_by_variable_attrs,
         encode_coords,
-        adjust_longitude_range,
     )
 }
 
@@ -209,7 +207,7 @@ pub fn parse_grib_dataset<'py>(
 /// message size, the message's bytes — at least sections 0-5; the data section
 /// is never needed). Offsets in the resulting tree point into the real file.
 #[pyfunction]
-#[pyo3(signature = (messages, drop_variables=None, only_variables=None, perserve_dims=None, filter_by_attrs=None, filter_by_variable_attrs=None, encode_coords=None, adjust_longitude_range=None))]
+#[pyo3(signature = (messages, drop_variables=None, only_variables=None, perserve_dims=None, filter_by_attrs=None, filter_by_variable_attrs=None, encode_coords=None))]
 #[allow(clippy::too_many_arguments)]
 pub fn parse_grib_dataset_from_headers<'py>(
     py: Python<'py>,
@@ -220,7 +218,6 @@ pub fn parse_grib_dataset_from_headers<'py>(
     filter_by_attrs: Option<&Bound<'py, PyDict>>,
     filter_by_variable_attrs: Option<&Bound<'py, PyDict>>,
     encode_coords: Option<bool>,
-    adjust_longitude_range: Option<bool>,
 ) -> PyResult<Bound<'py, PyDict>> {
     let mut mapping = HashMap::new();
     for (index, (byte_offset, message_size, bytes)) in messages.iter().enumerate() {
@@ -245,7 +242,6 @@ pub fn parse_grib_dataset_from_headers<'py>(
         filter_by_attrs,
         filter_by_variable_attrs,
         encode_coords,
-        adjust_longitude_range,
     )
 }
 
@@ -259,7 +255,6 @@ fn build_grib_dataset<'py>(
     filter_by_attrs: Option<&Bound<'py, PyDict>>,
     filter_by_variable_attrs: Option<&Bound<'py, PyDict>>,
     encode_coords: Option<bool>,
-    adjust_longitude_range: Option<bool>,
 ) -> PyResult<Bound<'py, PyDict>> {
     let drop_variables = if let Some(drop_variables) = drop_variables {
         drop_variables
@@ -300,7 +295,6 @@ fn build_grib_dataset<'py>(
         };
 
     let encode_coords = encode_coords.unwrap_or_default();
-    let adjust_longitude_range = adjust_longitude_range.unwrap_or_default();
 
     let mapping = mapping
         .into_iter()
@@ -416,7 +410,6 @@ fn build_grib_dataset<'py>(
             &filter_by_variable_attrs,
             filter_by_variable_attrs_defined,
             encode_coords,
-            adjust_longitude_range,
         )?;
         if !node_has_data_vars(&node)? {
             return Err(PyValueError::new_err("No variables remain after filtering"));
@@ -447,7 +440,6 @@ fn build_grib_dataset<'py>(
             &filter_by_variable_attrs,
             filter_by_variable_attrs_defined,
             encode_coords,
-            adjust_longitude_range,
         )?;
         if !node_has_data_vars(&node)? {
             continue;
@@ -529,7 +521,6 @@ fn build_group<'py>(
     filter_by_variable_attrs: &Bound<'py, PyDict>,
     filter_by_variable_attrs_defined: bool,
     encode_coords: bool,
-    adjust_longitude_range: bool,
 ) -> PyResult<Bound<'py, PyDict>> {
     let mut var_dims = var_mapping
         .keys()
@@ -1016,7 +1007,7 @@ fn build_group<'py>(
         latitude.set_item("dims", vec!["latitude"]).unwrap();
         latitude_metadata.set_item("axis", "Y").unwrap();
 
-        let (lat, lng) = first.2.latlng_adjusted(adjust_longitude_range);
+        let (lat, lng) = first.2.latlng();
         latitude
             .set_item("values", PyArray1::from_vec(py, lat))
             .unwrap();

--- a/python/src/dataset.rs
+++ b/python/src/dataset.rs
@@ -177,7 +177,7 @@ fn cf_grid_mapping<'py>(
 }
 
 #[pyfunction]
-#[pyo3(signature = (data, drop_variables=None, only_variables=None, perserve_dims=None, filter_by_attrs=None, filter_by_variable_attrs=None, encode_coords=None))]
+#[pyo3(signature = (data, drop_variables=None, only_variables=None, perserve_dims=None, filter_by_attrs=None, filter_by_variable_attrs=None, encode_coords=None, adjust_longitude_range=None))]
 #[allow(clippy::too_many_arguments)]
 pub fn parse_grib_dataset<'py>(
     py: Python<'py>,
@@ -188,6 +188,7 @@ pub fn parse_grib_dataset<'py>(
     filter_by_attrs: Option<&Bound<'py, PyDict>>,
     filter_by_variable_attrs: Option<&Bound<'py, PyDict>>,
     encode_coords: Option<bool>,
+    adjust_longitude_range: Option<bool>,
 ) -> PyResult<Bound<'py, PyDict>> {
     build_grib_dataset(
         py,
@@ -198,6 +199,7 @@ pub fn parse_grib_dataset<'py>(
         filter_by_attrs,
         filter_by_variable_attrs,
         encode_coords,
+        adjust_longitude_range,
     )
 }
 
@@ -207,7 +209,7 @@ pub fn parse_grib_dataset<'py>(
 /// message size, the message's bytes — at least sections 0-5; the data section
 /// is never needed). Offsets in the resulting tree point into the real file.
 #[pyfunction]
-#[pyo3(signature = (messages, drop_variables=None, only_variables=None, perserve_dims=None, filter_by_attrs=None, filter_by_variable_attrs=None, encode_coords=None))]
+#[pyo3(signature = (messages, drop_variables=None, only_variables=None, perserve_dims=None, filter_by_attrs=None, filter_by_variable_attrs=None, encode_coords=None, adjust_longitude_range=None))]
 #[allow(clippy::too_many_arguments)]
 pub fn parse_grib_dataset_from_headers<'py>(
     py: Python<'py>,
@@ -218,6 +220,7 @@ pub fn parse_grib_dataset_from_headers<'py>(
     filter_by_attrs: Option<&Bound<'py, PyDict>>,
     filter_by_variable_attrs: Option<&Bound<'py, PyDict>>,
     encode_coords: Option<bool>,
+    adjust_longitude_range: Option<bool>,
 ) -> PyResult<Bound<'py, PyDict>> {
     let mut mapping = HashMap::new();
     for (index, (byte_offset, message_size, bytes)) in messages.iter().enumerate() {
@@ -242,6 +245,7 @@ pub fn parse_grib_dataset_from_headers<'py>(
         filter_by_attrs,
         filter_by_variable_attrs,
         encode_coords,
+        adjust_longitude_range,
     )
 }
 
@@ -255,6 +259,7 @@ fn build_grib_dataset<'py>(
     filter_by_attrs: Option<&Bound<'py, PyDict>>,
     filter_by_variable_attrs: Option<&Bound<'py, PyDict>>,
     encode_coords: Option<bool>,
+    adjust_longitude_range: Option<bool>,
 ) -> PyResult<Bound<'py, PyDict>> {
     let drop_variables = if let Some(drop_variables) = drop_variables {
         drop_variables
@@ -295,6 +300,7 @@ fn build_grib_dataset<'py>(
         };
 
     let encode_coords = encode_coords.unwrap_or_default();
+    let adjust_longitude_range = adjust_longitude_range.unwrap_or_default();
 
     let mapping = mapping
         .into_iter()
@@ -410,6 +416,7 @@ fn build_grib_dataset<'py>(
             &filter_by_variable_attrs,
             filter_by_variable_attrs_defined,
             encode_coords,
+            adjust_longitude_range,
         )?;
         if !node_has_data_vars(&node)? {
             return Err(PyValueError::new_err("No variables remain after filtering"));
@@ -440,6 +447,7 @@ fn build_grib_dataset<'py>(
             &filter_by_variable_attrs,
             filter_by_variable_attrs_defined,
             encode_coords,
+            adjust_longitude_range,
         )?;
         if !node_has_data_vars(&node)? {
             continue;
@@ -521,6 +529,7 @@ fn build_group<'py>(
     filter_by_variable_attrs: &Bound<'py, PyDict>,
     filter_by_variable_attrs_defined: bool,
     encode_coords: bool,
+    adjust_longitude_range: bool,
 ) -> PyResult<Bound<'py, PyDict>> {
     let mut var_dims = var_mapping
         .keys()
@@ -1007,7 +1016,7 @@ fn build_group<'py>(
         latitude.set_item("dims", vec!["latitude"]).unwrap();
         latitude_metadata.set_item("axis", "Y").unwrap();
 
-        let (lat, lng) = first.2.latlng();
+        let (lat, lng) = first.2.latlng_adjusted(adjust_longitude_range);
         latitude
             .set_item("values", PyArray1::from_vec(py, lat))
             .unwrap();

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -9,6 +9,7 @@ use pyo3::wrap_pyfunction;
 use crate::dataset::parse_grib_dataset;
 use crate::dataset::parse_grib_dataset_from_headers;
 use crate::index::parse_grib_index;
+use crate::message::adjust_longitude_values;
 use crate::message::parse_grib_array;
 use crate::message::parse_grib_mapping;
 use crate::message::parse_grib_message;
@@ -25,6 +26,7 @@ fn _gribberish_python(_py: Python, m: &Bound<PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(parse_grib_dataset, m)?)?;
     m.add_function(wrap_pyfunction!(parse_grib_dataset_from_headers, m)?)?;
     m.add_function(wrap_pyfunction!(parse_grib_array, m)?)?;
+    m.add_function(wrap_pyfunction!(adjust_longitude_values, m)?)?;
     m.add_function(wrap_pyfunction!(parse_grib_index, m)?)?;
     Ok(())
 }

--- a/python/src/message.rs
+++ b/python/src/message.rs
@@ -210,6 +210,15 @@ pub fn parse_grib_array<'py>(
     Ok(PyArray::from_vec(py, values))
 }
 
+/// Wrap a global 0–360° longitude coordinate to a monotonic −180…180° axis,
+/// matching the data roll the codec applies. A no-op for grids that don't span
+/// the globe. Used by the VirtualiZarr parser to rewrap the inlined longitude
+/// coordinate at the boundary, keeping the eager dataset reader projection-faithful.
+#[pyfunction]
+pub fn adjust_longitude_values(py: Python<'_>, longitudes: Vec<f64>) -> Bound<'_, PyArray1<f64>> {
+    PyArray::from_vec(py, gribberish::adjust_longitude_values(longitudes))
+}
+
 #[pyfunction]
 pub fn parse_grib_message_metadata(data: &[u8], offset: usize) -> PyResult<GribMessageMetadata> {
     let message = Message::from_data(data, offset)

--- a/python/src/message.rs
+++ b/python/src/message.rs
@@ -152,11 +152,13 @@ impl GribMessageMetadata {
         )
     }
 
+    #[pyo3(signature = (adjust_longitude_range=false))]
     fn latlng<'py>(
         &self,
         py: Python<'py>,
+        adjust_longitude_range: bool,
     ) -> (Bound<'py, PyArray1<f64>>, Bound<'py, PyArray1<f64>>) {
-        let (lat, lng) = self.inner.latlng();
+        let (lat, lng) = self.inner.latlng_adjusted(adjust_longitude_range);
         (PyArray::from_vec(py, lat), PyArray::from_vec(py, lng))
     }
 
@@ -177,22 +179,35 @@ pub struct GribMessage {
 #[pymethods]
 impl GribMessage {
     fn data<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyArray1<f64>>> {
-        parse_grib_array(py, &self.raw_data, self.offset)
+        parse_grib_array(py, &self.raw_data, self.offset, false)
     }
 }
 
 #[pyfunction]
+#[pyo3(signature = (data, offset, adjust_longitude_range=false))]
 pub fn parse_grib_array<'py>(
     py: Python<'py>,
     data: &[u8],
     offset: usize,
+    adjust_longitude_range: bool,
 ) -> PyResult<Bound<'py, PyArray1<f64>>> {
     let message = Message::from_data(data, offset)
         .ok_or_else(|| PyTypeError::new_err("Failed to read GRIB message"))?;
-    let data = message
+    let values = message
         .data()
         .map_err(|e| PyTypeError::new_err(format!("Failed to decode GRIB data: {e}")))?;
-    Ok(PyArray::from_vec(py, data))
+    // For eligible global grids, roll the data columns so longitudes run
+    // -180..180 monotonically, matching the wrapped coordinates. The projector
+    // decides eligibility and the exact roll, so data and coords stay aligned.
+    let values = if adjust_longitude_range {
+        let projector = message
+            .latlng_projector()
+            .map_err(|e| PyTypeError::new_err(format!("Failed to build projection: {e}")))?;
+        projector.adjust_data_longitude(values, true)
+    } else {
+        values
+    };
+    Ok(PyArray::from_vec(py, values))
 }
 
 #[pyfunction]

--- a/python/tests/test_virtualizarr.py
+++ b/python/tests/test_virtualizarr.py
@@ -200,6 +200,85 @@ def test_use_index_matches_full_scan():
     )
 
 
+def test_adjust_longitude_range_global_grid():
+    """Opt-in longitude wrap: a 0–360° GFS grid becomes a monotonic −180…180°
+    store whose data is rolled to match, so a box straddling the prime meridian
+    slices cleanly (the gotcha from issue #156)."""
+    fname = "gfs.t18z.pgrb2.0p25.f186-RH.grib2"
+    nx, roll = 1440, 720
+
+    plain = _store_for(fname).to_virtual_dataset()
+    wrapped = _store_for(fname, adjust_longitude_range=True).to_virtual_dataset()
+
+    # default coordinate is the native 0..360 range
+    np.testing.assert_array_equal(plain.longitude.values[[0, -1]], [0.0, 359.75])
+
+    # wrapped coordinate is strictly monotonic over [-180, 180)
+    lon = wrapped.longitude.values
+    assert lon[0] == -180.0 and lon[-1] == 179.75
+    assert np.all(np.diff(lon) > 0)
+
+    # data stays aligned with the coordinate: reading through the wrapped store
+    # equals the plain store rolled along longitude by the same split column.
+    z_plain = zarr.open(_store_for(fname), mode="r")
+    z_wrapped = zarr.open(_store_for(fname, adjust_longitude_range=True), mode="r")
+    plain_data = np.asarray(z_plain["rh"][...])
+    wrapped_data = np.asarray(z_wrapped["rh"][...])
+    cols = (np.arange(nx) + roll) % nx
+    np.testing.assert_array_equal(wrapped_data, plain_data[..., cols])
+
+    # the issue's acceptance: with the wrapped coordinate + rolled data assembled
+    # into a dataset (as a consumer like icechunk does at read time), a box around
+    # the prime meridian slices cleanly to 161 columns — the native 0–360 store
+    # would silently drop the [-10, 0) half.
+    import xarray as xr
+
+    ds = xr.Dataset(
+        {"rh": (("time", "latitude", "longitude"), wrapped_data)},
+        coords={"longitude": lon},
+    )
+    box = ds.sel(longitude=slice(-10, 30))
+    assert box.sizes["longitude"] == 161
+    np.testing.assert_array_equal(box.longitude.values[[0, -1]], [-10.0, 30.0])
+
+
+def test_adjust_longitude_range_start_at_antimeridian():
+    """A grid that already starts at 180° (ECMWF/AIFS) is non-monotonic in 0–360
+    today; wrapping relabels the coordinate to monotonic −180…180 with no data
+    move (roll == 0), exercising the relabel-only branch."""
+    fname = "aifs-single-t500.grib2"
+
+    plain = _store_for(fname).to_virtual_dataset()
+    wrapped = _store_for(fname, adjust_longitude_range=True).to_virtual_dataset()
+
+    # native coordinate wraps mid-array (180..359.75, then 0..179.75)
+    assert plain.longitude.values[0] == 180.0 and plain.longitude.values[-1] == 179.75
+    assert not np.all(np.diff(plain.longitude.values) > 0)
+
+    # wrapped coordinate is monotonic -180..180
+    lon = wrapped.longitude.values
+    assert lon[0] == -180.0 and lon[-1] == 179.75
+    assert np.all(np.diff(lon) > 0)
+
+    # data is unchanged because the columns were already in -180..180 order
+    z_plain = zarr.open(_store_for(fname), mode="r")
+    z_wrapped = zarr.open(_store_for(fname, adjust_longitude_range=True), mode="r")
+    np.testing.assert_array_equal(
+        np.asarray(z_wrapped["tmp"][...]), np.asarray(z_plain["tmp"][...])
+    )
+
+
+def test_adjust_longitude_range_default_off_unchanged():
+    """Default-off parser is byte-for-byte the existing behaviour."""
+    fname = "gfs.t18z.pgrb2.0p25.f186-RH.grib2"
+    default = _store_for(fname).to_virtual_dataset()
+    explicit_off = _store_for(fname, adjust_longitude_range=False).to_virtual_dataset()
+    np.testing.assert_array_equal(
+        default.longitude.values, explicit_off.longitude.values
+    )
+    assert default.longitude.values[0] == 0.0
+
+
 def test_layer_variable_distinguished_by_second_surface():
     """Layer quantities whose bottom surface is constant but top varies (HRRR
     0-1000m vs 0-6000m wind shear) must not collapse into a single chunk slot.

--- a/python/tests/test_virtualizarr.py
+++ b/python/tests/test_virtualizarr.py
@@ -279,6 +279,25 @@ def test_adjust_longitude_range_default_off_unchanged():
     assert default.longitude.values[0] == 0.0
 
 
+def test_adjust_longitude_values_helper():
+    """The longitude-wrap kernel the parser calls on the inlined coordinate:
+    a global 0..360 axis becomes monotonic -180..180; a non-global axis is
+    returned unchanged."""
+    from gribberish import adjust_longitude_values
+
+    # Global 0.25° axis (1440 pts, 0..359.75): split at 180° -> -180..179.75.
+    native = np.arange(1440) * 0.25
+    wrapped = np.asarray(adjust_longitude_values(native))
+    assert wrapped[0] == -180.0 and wrapped[-1] == 179.75
+    assert np.all(np.diff(wrapped) > 0)
+
+    # Regional axis (90° wide) is not near-global -> returned unchanged.
+    regional = 10.0 + np.arange(360) * 0.25
+    np.testing.assert_array_equal(
+        np.asarray(adjust_longitude_values(regional)), regional
+    )
+
+
 def test_layer_variable_distinguished_by_second_surface():
     """Layer quantities whose bottom surface is constant but top varies (HRRR
     0-1000m vs 0-6000m wind shear) must not collapse into a single chunk slot.

--- a/python/tests/test_zarr_codec.py
+++ b/python/tests/test_zarr_codec.py
@@ -1,8 +1,114 @@
+from pathlib import Path
+
 import pytest
 
 import numpy as np
 
 zarr = pytest.importorskip("zarr")
+
+TEST_DATA = Path(__file__).resolve().parents[2] / "test-data"
+
+# GEFS 0.5° — first message (HGT) is a 361×720 global grid, lon 0..359.5. The
+# antimeridian (180°) sits on column 360, so the wrap rolls by exactly 360.
+GEAVG = "geavg.t12z.pgrb2a.0p50.f000"
+GEAVG_SHAPE = (361, 720)
+GEAVG_ROLL = 360
+
+
+async def _decode(codec, raw, shape, dtype="float64"):
+    from zarr.core.array_spec import ArraySpec, ArrayConfig
+    from zarr.core.buffer import default_buffer_prototype
+    from zarr.dtype import parse_dtype
+    from zarr.buffer.cpu import buffer_prototype
+
+    buffer = default_buffer_prototype().buffer.from_bytes(raw)
+    decoded = await codec._decode_single(
+        buffer,
+        ArraySpec(
+            shape=shape,
+            dtype=parse_dtype(dtype, zarr_format=3),
+            fill_value=0,
+            prototype=buffer_prototype,
+            config=ArrayConfig(order="C", write_empty_chunks=False),
+        ),
+    )
+    return decoded.as_ndarray_like()
+
+
+async def test_adjust_longitude_range_rolls_data():
+    """Opt-in wrap rolls decoded data left along longitude by the split column."""
+    from gribberish.zarr.codec import GribberishCodec
+
+    raw = (TEST_DATA / GEAVG).read_bytes()
+    # `var` is only special-cased for 'latitude'/'longitude'; any other name
+    # decodes the data array, so the name here is just a label.
+    native = await _decode(GribberishCodec("HGT"), raw, GEAVG_SHAPE)
+    adjusted = await _decode(
+        GribberishCodec("HGT", adjust_longitude_range=True), raw, GEAVG_SHAPE
+    )
+
+    nx = GEAVG_SHAPE[1]
+    cols = (np.arange(nx) + GEAVG_ROLL) % nx
+    np.testing.assert_array_equal(adjusted, native[:, cols])
+    assert not np.array_equal(adjusted, native)  # data really moved
+
+
+async def test_adjust_longitude_range_wraps_longitude_coordinate():
+    from gribberish.zarr.codec import GribberishCodec
+
+    raw = (TEST_DATA / GEAVG).read_bytes()
+    native = await _decode(GribberishCodec("longitude"), raw, (GEAVG_SHAPE[1],))
+    wrapped = await _decode(
+        GribberishCodec("longitude", adjust_longitude_range=True), raw, (GEAVG_SHAPE[1],)
+    )
+
+    # default is unchanged 0..360
+    assert native[0] == 0.0 and native[-1] == 359.5
+    # wrapped is strictly monotonic over [-180, 180)
+    assert wrapped[0] == -180.0 and wrapped[-1] == 179.5
+    assert np.all(np.diff(wrapped) > 0)
+    assert np.all((wrapped >= -180.0) & (wrapped < 180.0))
+
+
+async def test_adjust_longitude_range_leaves_latitude_untouched():
+    from gribberish.zarr.codec import GribberishCodec
+
+    raw = (TEST_DATA / GEAVG).read_bytes()
+    native = await _decode(GribberishCodec("latitude"), raw, (GEAVG_SHAPE[0],))
+    adjusted = await _decode(
+        GribberishCodec("latitude", adjust_longitude_range=True), raw, (GEAVG_SHAPE[0],)
+    )
+    np.testing.assert_array_equal(native, adjusted)
+
+
+async def test_adjust_longitude_range_noop_for_non_global_grid():
+    """A regional/projected (HRRR Lambert) grid is left untouched."""
+    from gribberish.zarr.codec import GribberishCodec
+
+    raw = (TEST_DATA / "hrrr.t06z.wrfsfcf01-UGRD.grib2").read_bytes()
+    shape = (1059, 1799)
+    native = await _decode(GribberishCodec("UGRD"), raw, shape)
+    adjusted = await _decode(
+        GribberishCodec("UGRD", adjust_longitude_range=True), raw, shape
+    )
+    np.testing.assert_array_equal(native, adjusted)
+
+
+def test_codec_config_roundtrips_adjust_flag():
+    from gribberish.zarr.codec import GribberishCodec
+
+    codec = GribberishCodec("HGT", adjust_longitude_range=True)
+    assert codec.to_dict() == {
+        "name": "gribberish",
+        "configuration": {"var": "HGT", "adjust_longitude_range": True},
+    }
+    assert GribberishCodec.from_dict(codec.to_dict()) == codec
+
+    # default off omits the flag, so existing stored metadata round-trips unchanged
+    plain = GribberishCodec("HGT")
+    assert plain.adjust_longitude_range is False
+    assert plain.to_dict() == {"name": "gribberish", "configuration": {"var": "HGT"}}
+    assert GribberishCodec.from_dict(plain.to_dict()) == plain
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Implements #156 

Opt-in `adjust_longitude_range` option that re-presents global 0-360° GRIB grids as a monotonic −180...180° axis by rolling data along the longitude dimension.

Key files
```
gribberish/                              
├── src/utils/iter/projection.rs   the roll kernel (wrap_roll) + adjust_longitude_values
├── src/message_metadata.rs        latlng_adjusted() passthrough
└── src/lib.rs                     re-export the kernel for the binding crate

python/                                  
├── src/message.rs                 adjust_longitude_values pyfunction
├── src/lib.rs                     register the pyfunction
├── gribberish/zarr/codec.py       GribberishCodec.adjust_longitude_range (rolls each chunk)
└── gribberish/virtualizarr/parser.py  GribberishParser flag; wraps the inlined longitude
```

Decisions as of first draft:
- Implemented in rust core.
- Same wrap_roll function used on data and longitude coords.
- Eligibility mirrors GDAL's GRIB_ADJUST_LONGITUDE_RANGE: data domain must be near-global, with ascending longitudes only; no-op for regional, descending, or projected grids even if adjust_longitude_range = true.
- Default off, so existing stored metadata round-trips unchanged.
- JS binding deferred.