### PR TITLE
Port 0..360 → -180..180 longitude wrapping to the JS bindings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -444,7 +444,7 @@ checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
 name = "gribberish"
-version = "1.1.1"
+version = "1.2.0"
 dependencies = [
  "bitflags 2.6.0",
  "bitvec",
@@ -464,7 +464,7 @@ dependencies = [
 
 [[package]]
 name = "gribberish-macros"
-version = "1.1.1"
+version = "1.2.0"
 dependencies = [
  "gribberish-types",
  "quote",
@@ -473,11 +473,11 @@ dependencies = [
 
 [[package]]
 name = "gribberish-types"
-version = "1.1.1"
+version = "1.2.0"
 
 [[package]]
 name = "gribberish_js"
-version = "1.1.1"
+version = "1.2.0"
 dependencies = [
  "chrono",
  "gribberish",
@@ -488,7 +488,7 @@ dependencies = [
 
 [[package]]
 name = "gribberishpy"
-version = "1.1.1"
+version = "1.2.0"
 dependencies = [
  "gribberish",
  "numpy",

--- a/gribberish/Cargo.toml
+++ b/gribberish/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gribberish"
-version = "1.1.1"
+version = "1.2.0"
 authors = ["Matthew Iannucci <mpiannucci@gmail.com>"]
 description = "Parse grib 2 files with Rust"
 edition = "2021"
@@ -11,8 +11,8 @@ categories = ["science", "encoding", "compression"]
 exclude = ["tests"]
 
 [dependencies]
-gribberish-types = { path = "../types", version = "1.1.1" }
-gribberish-macros = { path = "../macros", version = "1.1.1" }
+gribberish-types = { path = "../types", version = "1.2.0" }
+gribberish-macros = { path = "../macros", version = "1.2.0" }
 chrono = "0.4"
 openjpeg-sys = { version = "1.0.3", optional = true }
 png = { version = "0.17.2", optional = true }

--- a/js/Cargo.toml
+++ b/js/Cargo.toml
@@ -3,7 +3,7 @@
 authors = ["Matthew Iannucci <mpiannucci@gmail.com>"]
 edition = "2024"
 name = "gribberish_js"
-version = "1.1.1"
+version = "1.2.0"
 
 [lib]
 crate-type = ["cdylib"]
@@ -11,11 +11,11 @@ crate-type = ["cdylib"]
 [dependencies]
 napi = { version = "3.0.0", features = ["chrono_date"] }
 napi-derive = "3.0.0"
-gribberish = { path = "../gribberish", version = "1.1.1", default-features = false, features = ["png"] }
+gribberish = { path = "../gribberish", version = "1.2.0", default-features = false, features = ["png"] }
 chrono = "0.4"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-gribberish = { path = "../gribberish", version = "1.1.1", default-features = false, features = ["png", "jpeg"] }
+gribberish = { path = "../gribberish", version = "1.2.0", default-features = false, features = ["png", "jpeg"] }
 
 [build-dependencies]
 napi-build = "2"

--- a/js/__test__/index.spec.ts
+++ b/js/__test__/index.spec.ts
@@ -4,9 +4,22 @@ import { join, dirname } from 'node:path'
 
 import test from 'ava'
 
-import { GribMessage, GribMessageFactory, GribMessageMetadataFactory, parseGribIndex, parseMessagesFromBuffer } from '../index'
+import {
+  adjustLongitudeValues,
+  GribMessage,
+  GribMessageFactory,
+  GribMessageMetadataFactory,
+  parseGribIndex,
+  parseMessagesFromBuffer,
+} from '../index'
 
 const DATA_DIR = join(dirname(fileURLToPath(import.meta.url)), '../../test-data')
+
+// GEFS 0.5° — first message (HGT) is a 361×720 global grid, lon 0..359.5. The
+// antimeridian (180°) sits on column 360, so the wrap rolls by exactly 360.
+const GEAVG = 'geavg.t12z.pgrb2a.0p50.f000'
+const GEAVG_COLS = 720
+const GEAVG_ROLL = 360
 
 test('parseMessagesFromBuffer reads HRRR GRIB2 messages', (t) => {
   const data = readFileSync(join(DATA_DIR, 'hrrr.t06z.wrfsfcf01-TMP.grib2'))
@@ -104,6 +117,75 @@ test('parseGribIndex locates messages for ranged reads', (t) => {
   )
   t.like(ecmwf[0], { var: '2t', offset: 0, length: 224, forecastTime: '3' })
   t.is(ecmwf[0].keys.levtype, 'sfc')
+})
+
+test('latlngAdjusted wraps a global 0..360 grid to monotonic [-180, 180)', (t) => {
+  const data = readFileSync(join(DATA_DIR, GEAVG))
+  const msg = parseMessagesFromBuffer(data)[0]
+
+  const native = msg.latlng
+  const wrapped = msg.latlngAdjusted(true)
+
+  // Default longitude axis is the native 0..360; latitudes are untouched.
+  t.is(native.longitude[0], 0.0)
+  t.is(native.longitude[GEAVG_COLS - 1], 359.5)
+  t.deepEqual(wrapped.latitude, native.latitude)
+
+  // Wrapped longitude axis is strictly monotonic over [-180, 180).
+  const wrappedLon = wrapped.longitude.slice(0, GEAVG_COLS)
+  t.is(wrappedLon[0], -180.0)
+  t.is(wrappedLon[GEAVG_COLS - 1], 179.5)
+  for (let i = 1; i < wrappedLon.length; i++) {
+    t.true(wrappedLon[i] > wrappedLon[i - 1], `not monotonic at index ${i}`)
+  }
+  t.true(wrappedLon.every((lon) => lon >= -180.0 && lon < 180.0))
+
+  // adjustLongitudeRange=false is identical to the plain getter.
+  t.deepEqual(msg.latlngAdjusted(false).longitude, native.longitude)
+})
+
+test('dataAdjusted rolls a global grid left by the split column', (t) => {
+  const data = readFileSync(join(DATA_DIR, GEAVG))
+  const msg = parseMessagesFromBuffer(data)[0]
+
+  const native = msg.data
+  const adjusted = msg.dataAdjusted(true)
+  const rows = msg.gridShape.rows
+  const cols = msg.gridShape.cols
+  t.is(cols, GEAVG_COLS)
+
+  // Each row is rotated left by GEAVG_ROLL columns, matching the wrapped axis.
+  for (let r = 0; r < rows; r++) {
+    for (let c = 0; c < cols; c++) {
+      t.is(adjusted[r * cols + c], native[r * cols + ((c + GEAVG_ROLL) % cols)])
+    }
+  }
+
+  // Default and explicit-off both return the data unmoved.
+  t.deepEqual(msg.dataAdjusted(false), native)
+})
+
+test('adjusted accessors are a no-op for a non-global (HRRR Lambert) grid', (t) => {
+  const data = readFileSync(join(DATA_DIR, 'hrrr.t06z.wrfsfcf01-TMP.grib2'))
+  const msg = GribMessage.parseFromBuffer(data, 0)
+
+  t.deepEqual(msg.latlngAdjusted(true).longitude, msg.latlng.longitude)
+  t.deepEqual(msg.dataAdjusted(true), msg.data)
+})
+
+test('adjustLongitudeValues wraps a global axis and leaves a regional one unchanged', (t) => {
+  // Global 0..359.5 axis wraps to a monotonic [-180, 180) axis.
+  const global = Array.from({ length: GEAVG_COLS }, (_, i) => i * 0.5)
+  const wrapped = adjustLongitudeValues(global)
+  t.is(wrapped[0], -180.0)
+  t.is(wrapped[GEAVG_COLS - 1], 179.5)
+  for (let i = 1; i < wrapped.length; i++) {
+    t.true(wrapped[i] > wrapped[i - 1])
+  }
+
+  // A regional subset (not near-global) is returned unchanged.
+  const regional = Array.from({ length: 100 }, (_, i) => 200 + i * 0.25)
+  t.deepEqual(adjustLongitudeValues(regional), regional)
 })
 
 test('GribMessageFactory throws for unknown key', (t) => {

--- a/js/gribberish-js.wasi-browser.js
+++ b/js/gribberish-js.wasi-browser.js
@@ -59,5 +59,6 @@ export default __napiModule.exports
 export const GribMessage = __napiModule.exports.GribMessage
 export const GribMessageFactory = __napiModule.exports.GribMessageFactory
 export const GribMessageMetadataFactory = __napiModule.exports.GribMessageMetadataFactory
+export const adjustLongitudeValues = __napiModule.exports.adjustLongitudeValues
 export const parseGribIndex = __napiModule.exports.parseGribIndex
 export const parseMessagesFromBuffer = __napiModule.exports.parseMessagesFromBuffer

--- a/js/gribberish-js.wasi.cjs
+++ b/js/gribberish-js.wasi.cjs
@@ -111,5 +111,6 @@ module.exports = __napiModule.exports
 module.exports.GribMessage = __napiModule.exports.GribMessage
 module.exports.GribMessageFactory = __napiModule.exports.GribMessageFactory
 module.exports.GribMessageMetadataFactory = __napiModule.exports.GribMessageMetadataFactory
+module.exports.adjustLongitudeValues = __napiModule.exports.adjustLongitudeValues
 module.exports.parseGribIndex = __napiModule.exports.parseGribIndex
 module.exports.parseMessagesFromBuffer = __napiModule.exports.parseMessagesFromBuffer

--- a/js/index.d.ts
+++ b/js/index.d.ts
@@ -13,11 +13,26 @@ export declare class GribMessage {
   get crs(): string
   get gridShape(): GridShape
   get latlng(): LatLng
+  /**
+   * Like the `latlng` getter, but when `adjustLongitudeRange` is set the
+   * longitudes of an eligible near-global grid are wrapped from `[0, 360)` to a
+   * monotonic `[-180, 180)` axis. Pair with `dataAdjusted(true)` so the values
+   * stay aligned with the wrapped coordinates. A no-op for grids that don't
+   * span the globe (returns the same as `latlng`).
+   */
+  latlngAdjusted(adjustLongitudeRange: boolean): LatLng
   get isRegularGrid(): boolean
   get hasBitmap(): boolean
   get perturbationNumber(): number | null
   get numberOfEnsembleMembers(): number | null
   get data(): Array<number>
+  /**
+   * Like the `data` getter, but when `adjustLongitudeRange` is set the decoded
+   * values of an eligible near-global grid have their columns rolled to match a
+   * `[-180, 180)` longitude axis, staying aligned with `latlngAdjusted(true)`.
+   * A no-op for grids that don't span the globe (returns the same as `data`).
+   */
+  dataAdjusted(adjustLongitudeRange: boolean): Array<number>
 }
 
 export declare class GribMessageFactory {
@@ -31,6 +46,14 @@ export declare class GribMessageMetadataFactory {
   get availableMessages(): Array<string>
   getMessage(key: string): GribMessage
 }
+
+/**
+ * Wrap a `[0, 360)` longitude coordinate axis to a monotonic `[-180, 180)`
+ * range, matching the column roll `dataAdjusted` applies to the values. A
+ * no-op for axes that aren't eligible near-global ascending grids (returns the
+ * input unchanged), so it is safe to call on any longitude array.
+ */
+export declare function adjustLongitudeValues(longitudes: Array<number>): Array<number>
 
 /**
  * One entry of a GRIB sidecar index file (NOAA wgrib2 `.idx` or ECMWF

--- a/js/index.js
+++ b/js/index.js
@@ -80,8 +80,8 @@ function requireNative() {
       try {
         const binding = require('@mattnucc/gribberish-android-arm64')
         const bindingPackageVersion = require('@mattnucc/gribberish-android-arm64/package.json').version
-        if (bindingPackageVersion !== '1.0.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.0.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -96,8 +96,8 @@ function requireNative() {
       try {
         const binding = require('@mattnucc/gribberish-android-arm-eabi')
         const bindingPackageVersion = require('@mattnucc/gribberish-android-arm-eabi/package.json').version
-        if (bindingPackageVersion !== '1.0.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.0.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -116,8 +116,8 @@ function requireNative() {
       try {
         const binding = require('@mattnucc/gribberish-win32-x64-msvc')
         const bindingPackageVersion = require('@mattnucc/gribberish-win32-x64-msvc/package.json').version
-        if (bindingPackageVersion !== '1.0.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.0.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -132,8 +132,8 @@ function requireNative() {
       try {
         const binding = require('@mattnucc/gribberish-win32-ia32-msvc')
         const bindingPackageVersion = require('@mattnucc/gribberish-win32-ia32-msvc/package.json').version
-        if (bindingPackageVersion !== '1.0.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.0.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -148,8 +148,8 @@ function requireNative() {
       try {
         const binding = require('@mattnucc/gribberish-win32-arm64-msvc')
         const bindingPackageVersion = require('@mattnucc/gribberish-win32-arm64-msvc/package.json').version
-        if (bindingPackageVersion !== '1.0.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.0.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -167,8 +167,8 @@ function requireNative() {
     try {
       const binding = require('@mattnucc/gribberish-darwin-universal')
       const bindingPackageVersion = require('@mattnucc/gribberish-darwin-universal/package.json').version
-      if (bindingPackageVersion !== '1.0.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-        throw new Error(`Native binding package version mismatch, expected 1.0.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+      if (bindingPackageVersion !== '1.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+        throw new Error(`Native binding package version mismatch, expected 1.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
       }
       return binding
     } catch (e) {
@@ -183,8 +183,8 @@ function requireNative() {
       try {
         const binding = require('@mattnucc/gribberish-darwin-x64')
         const bindingPackageVersion = require('@mattnucc/gribberish-darwin-x64/package.json').version
-        if (bindingPackageVersion !== '1.0.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.0.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -199,8 +199,8 @@ function requireNative() {
       try {
         const binding = require('@mattnucc/gribberish-darwin-arm64')
         const bindingPackageVersion = require('@mattnucc/gribberish-darwin-arm64/package.json').version
-        if (bindingPackageVersion !== '1.0.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.0.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -219,8 +219,8 @@ function requireNative() {
       try {
         const binding = require('@mattnucc/gribberish-freebsd-x64')
         const bindingPackageVersion = require('@mattnucc/gribberish-freebsd-x64/package.json').version
-        if (bindingPackageVersion !== '1.0.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.0.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -235,8 +235,8 @@ function requireNative() {
       try {
         const binding = require('@mattnucc/gribberish-freebsd-arm64')
         const bindingPackageVersion = require('@mattnucc/gribberish-freebsd-arm64/package.json').version
-        if (bindingPackageVersion !== '1.0.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.0.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -256,8 +256,8 @@ function requireNative() {
         try {
           const binding = require('@mattnucc/gribberish-linux-x64-musl')
           const bindingPackageVersion = require('@mattnucc/gribberish-linux-x64-musl/package.json').version
-          if (bindingPackageVersion !== '1.0.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 1.0.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -272,8 +272,8 @@ function requireNative() {
         try {
           const binding = require('@mattnucc/gribberish-linux-x64-gnu')
           const bindingPackageVersion = require('@mattnucc/gribberish-linux-x64-gnu/package.json').version
-          if (bindingPackageVersion !== '1.0.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 1.0.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -290,8 +290,8 @@ function requireNative() {
         try {
           const binding = require('@mattnucc/gribberish-linux-arm64-musl')
           const bindingPackageVersion = require('@mattnucc/gribberish-linux-arm64-musl/package.json').version
-          if (bindingPackageVersion !== '1.0.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 1.0.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -306,8 +306,8 @@ function requireNative() {
         try {
           const binding = require('@mattnucc/gribberish-linux-arm64-gnu')
           const bindingPackageVersion = require('@mattnucc/gribberish-linux-arm64-gnu/package.json').version
-          if (bindingPackageVersion !== '1.0.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 1.0.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -324,8 +324,8 @@ function requireNative() {
         try {
           const binding = require('@mattnucc/gribberish-linux-arm-musleabihf')
           const bindingPackageVersion = require('@mattnucc/gribberish-linux-arm-musleabihf/package.json').version
-          if (bindingPackageVersion !== '1.0.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 1.0.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -340,8 +340,8 @@ function requireNative() {
         try {
           const binding = require('@mattnucc/gribberish-linux-arm-gnueabihf')
           const bindingPackageVersion = require('@mattnucc/gribberish-linux-arm-gnueabihf/package.json').version
-          if (bindingPackageVersion !== '1.0.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 1.0.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -358,8 +358,8 @@ function requireNative() {
         try {
           const binding = require('@mattnucc/gribberish-linux-loong64-musl')
           const bindingPackageVersion = require('@mattnucc/gribberish-linux-loong64-musl/package.json').version
-          if (bindingPackageVersion !== '1.0.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 1.0.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -374,8 +374,8 @@ function requireNative() {
         try {
           const binding = require('@mattnucc/gribberish-linux-loong64-gnu')
           const bindingPackageVersion = require('@mattnucc/gribberish-linux-loong64-gnu/package.json').version
-          if (bindingPackageVersion !== '1.0.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 1.0.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -392,8 +392,8 @@ function requireNative() {
         try {
           const binding = require('@mattnucc/gribberish-linux-riscv64-musl')
           const bindingPackageVersion = require('@mattnucc/gribberish-linux-riscv64-musl/package.json').version
-          if (bindingPackageVersion !== '1.0.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 1.0.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -408,8 +408,8 @@ function requireNative() {
         try {
           const binding = require('@mattnucc/gribberish-linux-riscv64-gnu')
           const bindingPackageVersion = require('@mattnucc/gribberish-linux-riscv64-gnu/package.json').version
-          if (bindingPackageVersion !== '1.0.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 1.0.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -425,8 +425,8 @@ function requireNative() {
       try {
         const binding = require('@mattnucc/gribberish-linux-ppc64-gnu')
         const bindingPackageVersion = require('@mattnucc/gribberish-linux-ppc64-gnu/package.json').version
-        if (bindingPackageVersion !== '1.0.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.0.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -441,8 +441,8 @@ function requireNative() {
       try {
         const binding = require('@mattnucc/gribberish-linux-s390x-gnu')
         const bindingPackageVersion = require('@mattnucc/gribberish-linux-s390x-gnu/package.json').version
-        if (bindingPackageVersion !== '1.0.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.0.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -461,8 +461,8 @@ function requireNative() {
       try {
         const binding = require('@mattnucc/gribberish-openharmony-arm64')
         const bindingPackageVersion = require('@mattnucc/gribberish-openharmony-arm64/package.json').version
-        if (bindingPackageVersion !== '1.0.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.0.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -477,8 +477,8 @@ function requireNative() {
       try {
         const binding = require('@mattnucc/gribberish-openharmony-x64')
         const bindingPackageVersion = require('@mattnucc/gribberish-openharmony-x64/package.json').version
-        if (bindingPackageVersion !== '1.0.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.0.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -493,8 +493,8 @@ function requireNative() {
       try {
         const binding = require('@mattnucc/gribberish-openharmony-arm')
         const bindingPackageVersion = require('@mattnucc/gribberish-openharmony-arm/package.json').version
-        if (bindingPackageVersion !== '1.0.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.0.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -560,5 +560,6 @@ module.exports = nativeBinding
 module.exports.GribMessage = nativeBinding.GribMessage
 module.exports.GribMessageFactory = nativeBinding.GribMessageFactory
 module.exports.GribMessageMetadataFactory = nativeBinding.GribMessageMetadataFactory
+module.exports.adjustLongitudeValues = nativeBinding.adjustLongitudeValues
 module.exports.parseGribIndex = nativeBinding.parseGribIndex
 module.exports.parseMessagesFromBuffer = nativeBinding.parseMessagesFromBuffer

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mattnucc/gribberish",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "JavaScript bindings for gribberish, a GRIB2 parsing library",
   "main": "index.js",
   "repository": {

--- a/js/src/lib.rs
+++ b/js/src/lib.rs
@@ -3,6 +3,7 @@
 use std::collections::HashMap;
 
 use gribberish::{
+  adjust_longitude_values as adjust_longitude_values_core,
   data_message::DataMessage,
   index::parse_index,
   message::{read_message, read_messages, scan_messages},
@@ -103,6 +104,20 @@ impl GribMessage {
     }
   }
 
+  /// Like the `latlng` getter, but when `adjustLongitudeRange` is set the
+  /// longitudes of an eligible near-global grid are wrapped from `[0, 360)` to a
+  /// monotonic `[-180, 180)` axis. Pair with `dataAdjusted(true)` so the values
+  /// stay aligned with the wrapped coordinates. A no-op for grids that don't
+  /// span the globe (returns the same as `latlng`).
+  #[napi]
+  pub fn latlng_adjusted(&self, adjust_longitude_range: bool) -> LatLng {
+    let (latitude, longitude) = self.inner.metadata.latlng_adjusted(adjust_longitude_range);
+    LatLng {
+      latitude,
+      longitude,
+    }
+  }
+
   #[napi(getter)]
   pub fn is_regular_grid(&self) -> bool {
     self.inner.metadata.is_regular_grid
@@ -130,6 +145,19 @@ impl GribMessage {
   #[napi(getter)]
   pub fn data(&self) -> Vec<f64> {
     self.inner.data.clone()
+  }
+
+  /// Like the `data` getter, but when `adjustLongitudeRange` is set the decoded
+  /// values of an eligible near-global grid have their columns rolled to match a
+  /// `[-180, 180)` longitude axis, staying aligned with `latlngAdjusted(true)`.
+  /// A no-op for grids that don't span the globe (returns the same as `data`).
+  #[napi]
+  pub fn data_adjusted(&self, adjust_longitude_range: bool) -> Vec<f64> {
+    self
+      .inner
+      .metadata
+      .projector
+      .adjust_data_longitude(self.inner.data.clone(), adjust_longitude_range)
   }
 }
 
@@ -188,6 +216,15 @@ pub fn parse_grib_index(data: String, file_size: Option<i64>) -> napi::Result<Ve
       })
       .collect(),
   )
+}
+
+/// Wrap a `[0, 360)` longitude coordinate axis to a monotonic `[-180, 180)`
+/// range, matching the column roll `dataAdjusted` applies to the values. A
+/// no-op for axes that aren't eligible near-global ascending grids (returns the
+/// input unchanged), so it is safe to call on any longitude array.
+#[napi]
+pub fn adjust_longitude_values(longitudes: Vec<f64>) -> Vec<f64> {
+  adjust_longitude_values_core(longitudes)
 }
 
 #[napi]

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gribberish-macros"
-version = "1.1.1"
+version = "1.2.0"
 authors = ["Matthew Iannucci <mpiannucci@gmail.com>"]
 description = "Procedural macros for the gribberish crate"
 edition = "2021"
@@ -10,7 +10,7 @@ repository = "https://github.com/mpiannucci/gribberish"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-gribberish-types = { path = "./../types", version = "1.1.1" }
+gribberish-types = { path = "./../types", version = "1.2.0" }
 syn = { version = "1.0", features = ["full"] }
 quote = "1.0"
 

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gribberishpy"
-version = "1.1.1"
+version = "1.2.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -10,5 +10,5 @@ crate-type = ["cdylib"]
 
 [dependencies]
 pyo3 = "0.27.0"
-gribberish = { path = "../gribberish", version = "1.1.1" }
+gribberish = { path = "../gribberish", version = "1.2.0" }
 numpy = "0.27.0"

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gribberish-types"
-version = "1.1.1"
+version = "1.2.0"
 authors = ["Matthew Iannucci <mpiannucci@gmail.com>"]
 description = "Common types for the gribberish crate"
 edition = "2021"


### PR DESCRIPTION
[#161](https://github.com/mpiannucci/gribberish/pull/161) added an opt-in longitude-wrapping option (`0…360` → monotonic `[-180, 180)`) to the core crate and the Python bindings, but the napi (JS) bindings were never updated. This ports the same surface to JS so a browser/Node consumer plotting a global GFS/GEFS field on a `-180…180` map gets wrapped coordinates and aligned data instead of the raw `0…360` layout.

Also bumps the version to 1.2.0 in line with semver
