### PR TITLE
Add collapse_groups flag for stable group layout (#165)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -444,7 +444,7 @@ checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
 name = "gribberish"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "bitflags 2.6.0",
  "bitvec",
@@ -464,7 +464,7 @@ dependencies = [
 
 [[package]]
 name = "gribberish-macros"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "gribberish-types",
  "quote",
@@ -473,11 +473,11 @@ dependencies = [
 
 [[package]]
 name = "gribberish-types"
-version = "1.2.0"
+version = "1.3.0"
 
 [[package]]
 name = "gribberish_js"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "chrono",
  "gribberish",
@@ -488,7 +488,7 @@ dependencies = [
 
 [[package]]
 name = "gribberishpy"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "gribberish",
  "numpy",

--- a/gribberish/Cargo.toml
+++ b/gribberish/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gribberish"
-version = "1.2.0"
+version = "1.3.0"
 authors = ["Matthew Iannucci <mpiannucci@gmail.com>"]
 description = "Parse grib 2 files with Rust"
 edition = "2021"
@@ -11,8 +11,8 @@ categories = ["science", "encoding", "compression"]
 exclude = ["tests"]
 
 [dependencies]
-gribberish-types = { path = "../types", version = "1.2.0" }
-gribberish-macros = { path = "../macros", version = "1.2.0" }
+gribberish-types = { path = "../types", version = "1.3.0" }
+gribberish-macros = { path = "../macros", version = "1.3.0" }
 chrono = "0.4"
 openjpeg-sys = { version = "1.0.3", optional = true }
 png = { version = "0.17.2", optional = true }

--- a/js/Cargo.toml
+++ b/js/Cargo.toml
@@ -3,7 +3,7 @@
 authors = ["Matthew Iannucci <mpiannucci@gmail.com>"]
 edition = "2024"
 name = "gribberish_js"
-version = "1.2.0"
+version = "1.3.0"
 
 [lib]
 crate-type = ["cdylib"]
@@ -11,11 +11,11 @@ crate-type = ["cdylib"]
 [dependencies]
 napi = { version = "3.0.0", features = ["chrono_date"] }
 napi-derive = "3.0.0"
-gribberish = { path = "../gribberish", version = "1.2.0", default-features = false, features = ["png"] }
+gribberish = { path = "../gribberish", version = "1.3.0", default-features = false, features = ["png"] }
 chrono = "0.4"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-gribberish = { path = "../gribberish", version = "1.2.0", default-features = false, features = ["png", "jpeg"] }
+gribberish = { path = "../gribberish", version = "1.3.0", default-features = false, features = ["png", "jpeg"] }
 
 [build-dependencies]
 napi-build = "2"

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mattnucc/gribberish",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "JavaScript bindings for gribberish, a GRIB2 parsing library",
   "main": "index.js",
   "repository": {

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gribberish-macros"
-version = "1.2.0"
+version = "1.3.0"
 authors = ["Matthew Iannucci <mpiannucci@gmail.com>"]
 description = "Procedural macros for the gribberish crate"
 edition = "2021"
@@ -10,7 +10,7 @@ repository = "https://github.com/mpiannucci/gribberish"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-gribberish-types = { path = "./../types", version = "1.2.0" }
+gribberish-types = { path = "./../types", version = "1.3.0" }
 syn = { version = "1.0", features = ["full"] }
 quote = "1.0"
 

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gribberishpy"
-version = "1.2.0"
+version = "1.3.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -10,5 +10,5 @@ crate-type = ["cdylib"]
 
 [dependencies]
 pyo3 = "0.27.0"
-gribberish = { path = "../gribberish", version = "1.2.0" }
+gribberish = { path = "../gribberish", version = "1.3.0" }
 numpy = "0.27.0"

--- a/python/README.md
+++ b/python/README.md
@@ -59,11 +59,14 @@ For direct usage, see [dump_dataset.py](./examples/dump_dataset.py) or compare w
 
 ### `xarray`
 
-To use with `xarray`, simply specify the `gribberish` backend when loading a `grib2` file:
+To use with `xarray`, simply specify the `gribberish` backend when loading a `grib2` file. By default a file is split into nested groups by surface type and product kind, so open one group at a time (or the whole tree with `xr.open_datatree`):
 
 ```
 import xarray as xr
-ds = xr.open_dataset('gfswave.20210826.t12z.atlocn.0p16.f000.grib2', engine='gribberish')
+ds = xr.open_dataset('gfswave.20210826.t12z.atlocn.0p16.f000.grib2', engine='gribberish', group='sfc/instant')
+
+# Or fold everything into one dataset where possible:
+ds = xr.open_dataset('gfswave.20210826.t12z.atlocn.0p16.f000.grib2', engine='gribberish', collapse_groups=True)
 ```
 
 Remote files (`s3://`, `gs://`, `https://`) work the same way and are fetched
@@ -82,7 +85,7 @@ Some examples are provided:
 
 ### `VirtualiZarr`
 
-This package can build virtual datasets with [`VirtualiZarr`](https://virtualizarr.readthedocs.io/) using the `GribberishParser`. Conflicting hypercubes (e.g. the same variable at different level types, or instantaneous vs. accumulated fields) are split into nested groups, matching the way `cfgrib` breaks a file into multiple datasets:
+This package can build virtual datasets with [`VirtualiZarr`](https://virtualizarr.readthedocs.io/) using the `GribberishParser`. By default each variable is nested under its surface type and product kind (e.g. `/hag/instant`, `/sfc/instant`), matching the way `cfgrib` breaks a file into multiple datasets. This layout is **content-independent** — a variable lands at the same group path in every same-schema file, so multi-file datacubes concatenate cleanly across a forecast sequence:
 
 ```python
 import virtualizarr as vz
@@ -93,11 +96,15 @@ from gribberish.virtualizarr import GribberishParser
 registry = ObjectStoreRegistry({"file://": LocalStore()})
 store = GribberishParser()("file:///path/to/file.grib2", registry)
 
-# A single, conflict-free file opens directly:
-vds = store.to_virtual_dataset()
-
-# A file with conflicting hypercubes opens as a tree of groups:
+# The file opens as a tree of standalone group datasets:
 vdt = store.to_virtual_datatree()
+
+# Pass collapse_groups=True to fold a conflict-free file into one root dataset
+# (levels/kinds become dimensions). Cleaner per file, but the group layout then
+# depends on the file's content, so the same variable can land at different
+# paths across files — which breaks concatenation.
+store = GribberishParser(collapse_groups=True)("file:///path/to/file.grib2", registry)
+vds = store.to_virtual_dataset()
 ```
 
 `GribberishParser` also accepts `use_index=` to build manifests from a sidecar

--- a/python/gribberish/gribberish_backend.py
+++ b/python/gribberish/gribberish_backend.py
@@ -149,11 +149,17 @@ class GribberishBackend(BackendEntrypoint):
 
     Adapted from https://xarray.pydata.org/en/stable/internals/how-to-add-new-backend.html
 
-    Conflicting hypercubes (a variable at multiple level types, or
-    instantaneous vs. accumulated/derived/probability products) are exposed as
-    separate groups, mirroring the way ``cfgrib`` breaks a file into multiple
-    datasets. Use ``group=`` to select one, or ``xarray.open_datatree`` /
-    ``xarray.open_groups`` to get them all. A conflict-free file opens directly.
+    By default the file is split into nested groups by surface type and product
+    kind (a variable at multiple level types, or instantaneous vs.
+    accumulated/derived/probability products), mirroring the way ``cfgrib``
+    breaks a file into multiple datasets. Use ``group=`` to select one, or
+    ``xarray.open_datatree`` / ``xarray.open_groups`` to get them all. This
+    layout is **content-independent**: a variable lands at the same group path
+    (e.g. ``/hag/instant``) in every same-schema file, so multi-file workflows
+    line up. Pass ``collapse_groups=True`` to instead fold everything into one
+    root dataset where possible (a subgroup appears only when a variable in this
+    file actually spans more than one value) — cleaner for a single file, but
+    the group path then depends on the file's content.
 
     Within a group, variables spanning different value sets of the same
     coordinate type get index-suffixed dimensions (``isobar_0``, ``isobar_1``,
@@ -178,7 +184,7 @@ class GribberishBackend(BackendEntrypoint):
 
     def _parse(self, filename_or_obj, storage_options, drop_variables,
                only_variables, perserve_dims, filter_by_attrs,
-               filter_by_variable_attrs, use_index):
+               filter_by_variable_attrs, use_index, collapse_groups):
         store, path = _store_and_path(filename_or_obj, storage_options)
         raw_data, file_offsets = _read_grib_bytes(
             store, path, use_index, only_variables, drop_variables
@@ -190,6 +196,7 @@ class GribberishBackend(BackendEntrypoint):
             perserve_dims=perserve_dims,
             filter_by_attrs=filter_by_attrs,
             filter_by_variable_attrs=filter_by_variable_attrs,
+            collapse_groups=collapse_groups,
         )
         if file_offsets is not None:
             _remap_offsets(tree, file_offsets)
@@ -207,11 +214,13 @@ class GribberishBackend(BackendEntrypoint):
         filter_by_attrs=None,
         filter_by_variable_attrs=None,
         use_index=False,
+        collapse_groups=False,
     ):
         storage_options = storage_options or {}
         tree = self._parse(
             filename_or_obj, storage_options, drop_variables, only_variables,
             perserve_dims, filter_by_attrs, filter_by_variable_attrs, use_index,
+            collapse_groups,
         )
 
         has_groups = bool(tree.get("groups"))
@@ -237,11 +246,13 @@ class GribberishBackend(BackendEntrypoint):
         filter_by_attrs=None,
         filter_by_variable_attrs=None,
         use_index=False,
+        collapse_groups=False,
     ):
         storage_options = storage_options or {}
         tree = self._parse(
             filename_or_obj, storage_options, drop_variables, only_variables,
             perserve_dims, filter_by_attrs, filter_by_variable_attrs, use_index,
+            collapse_groups,
         )
         return {
             path: _node_to_dataset(node, filename_or_obj, storage_options)
@@ -262,6 +273,7 @@ class GribberishBackend(BackendEntrypoint):
         "filter_by_attrs",
         "filter_by_variable_attrs",
         "use_index",
+        "collapse_groups",
         "storage_options",
     ]
 

--- a/python/gribberish/virtualizarr/parser.py
+++ b/python/gribberish/virtualizarr/parser.py
@@ -1,11 +1,15 @@
 """VirtualiZarr parser for GRIB2 files, backed by gribberish.
 
 Each GRIB message is a single chunk decoded at read time by the
-``gribberish`` zarr codec. Conflicting hypercubes (a variable spanning
-multiple level types, or instantaneous vs. accumulated/derived/probability
-products) are split into nested groups, mirroring the way ``cfgrib`` breaks a
-file into multiple datasets. A conflict-free file is a single root dataset with
-levels expressed as dimensions.
+``gribberish`` zarr codec. By default variables are split into nested groups by
+surface type and product kind (a variable spanning multiple level types, or
+instantaneous vs. accumulated/derived/probability products), mirroring the way
+``cfgrib`` breaks a file into multiple datasets. This layout is
+content-independent — a variable lands at the same path (e.g. ``/hag/instant``)
+in every same-schema file, so multi-file datacubes concatenate cleanly. Pass
+``collapse_groups=True`` to fold everything into one root dataset where possible,
+with levels expressed as dimensions (cleaner per file, but the layout then
+depends on the file's content).
 """
 
 from __future__ import annotations
@@ -261,6 +265,19 @@ class GribberishParser:
         codec is told to roll its decoded chunk along the longitude axis to
         match, so the published store slices cleanly across the prime meridian.
         Default off; a no-op for grids that don't span the globe.
+    collapse_groups
+        Default off, which gives a **stable, content-independent** group layout:
+        every variable is nested under its surface-type and product-kind
+        subgroups (e.g. ``/hag/instant``) regardless of whether anything in the
+        file conflicts, so a variable's group path depends only on its own
+        metadata and is identical across every file in a forecast sequence —
+        letting multi-file datacubes concatenate cleanly. Turn it **on** to
+        collapse everything into one root dataset where possible (levels and
+        kinds become dimensions, and a subgroup only appears when a variable in
+        *this* file actually spans more than one of its values). That is cleaner
+        for a single file but makes the layout content-dependent: the same
+        variable can land at different paths across files (``/hag/instant`` in
+        one, ``/instant`` in another), which breaks concatenation.
     """
 
     def __init__(
@@ -272,6 +289,7 @@ class GribberishParser:
         filter_by_variable_attrs: dict[str, Any] | None = None,
         use_index: bool | str = False,
         adjust_longitude_range: bool = False,
+        collapse_groups: bool = False,
     ) -> None:
         self.drop_variables = drop_variables
         self.only_variables = only_variables
@@ -280,6 +298,7 @@ class GribberishParser:
         self.filter_by_variable_attrs = filter_by_variable_attrs
         self.use_index = use_index
         self.adjust_longitude_range = adjust_longitude_range
+        self.collapse_groups = collapse_groups
 
     def _filter_kwargs(self) -> dict[str, Any]:
         return dict(
@@ -290,6 +309,7 @@ class GribberishParser:
             filter_by_variable_attrs=self.filter_by_variable_attrs,
             # Keep projected lat/lon as references rather than materializing them.
             encode_coords=True,
+            collapse_groups=self.collapse_groups,
         )
 
     def _parse_via_index(self, store, path: str, entries) -> dict[str, Any]:

--- a/python/src/dataset.rs
+++ b/python/src/dataset.rs
@@ -177,7 +177,7 @@ fn cf_grid_mapping<'py>(
 }
 
 #[pyfunction]
-#[pyo3(signature = (data, drop_variables=None, only_variables=None, perserve_dims=None, filter_by_attrs=None, filter_by_variable_attrs=None, encode_coords=None))]
+#[pyo3(signature = (data, drop_variables=None, only_variables=None, perserve_dims=None, filter_by_attrs=None, filter_by_variable_attrs=None, encode_coords=None, collapse_groups=None))]
 #[allow(clippy::too_many_arguments)]
 pub fn parse_grib_dataset<'py>(
     py: Python<'py>,
@@ -188,6 +188,7 @@ pub fn parse_grib_dataset<'py>(
     filter_by_attrs: Option<&Bound<'py, PyDict>>,
     filter_by_variable_attrs: Option<&Bound<'py, PyDict>>,
     encode_coords: Option<bool>,
+    collapse_groups: Option<bool>,
 ) -> PyResult<Bound<'py, PyDict>> {
     build_grib_dataset(
         py,
@@ -198,6 +199,7 @@ pub fn parse_grib_dataset<'py>(
         filter_by_attrs,
         filter_by_variable_attrs,
         encode_coords,
+        collapse_groups,
     )
 }
 
@@ -207,7 +209,7 @@ pub fn parse_grib_dataset<'py>(
 /// message size, the message's bytes — at least sections 0-5; the data section
 /// is never needed). Offsets in the resulting tree point into the real file.
 #[pyfunction]
-#[pyo3(signature = (messages, drop_variables=None, only_variables=None, perserve_dims=None, filter_by_attrs=None, filter_by_variable_attrs=None, encode_coords=None))]
+#[pyo3(signature = (messages, drop_variables=None, only_variables=None, perserve_dims=None, filter_by_attrs=None, filter_by_variable_attrs=None, encode_coords=None, collapse_groups=None))]
 #[allow(clippy::too_many_arguments)]
 pub fn parse_grib_dataset_from_headers<'py>(
     py: Python<'py>,
@@ -218,6 +220,7 @@ pub fn parse_grib_dataset_from_headers<'py>(
     filter_by_attrs: Option<&Bound<'py, PyDict>>,
     filter_by_variable_attrs: Option<&Bound<'py, PyDict>>,
     encode_coords: Option<bool>,
+    collapse_groups: Option<bool>,
 ) -> PyResult<Bound<'py, PyDict>> {
     let mut mapping = HashMap::new();
     for (index, (byte_offset, message_size, bytes)) in messages.iter().enumerate() {
@@ -242,6 +245,7 @@ pub fn parse_grib_dataset_from_headers<'py>(
         filter_by_attrs,
         filter_by_variable_attrs,
         encode_coords,
+        collapse_groups,
     )
 }
 
@@ -255,7 +259,9 @@ fn build_grib_dataset<'py>(
     filter_by_attrs: Option<&Bound<'py, PyDict>>,
     filter_by_variable_attrs: Option<&Bound<'py, PyDict>>,
     encode_coords: Option<bool>,
+    collapse_groups: Option<bool>,
 ) -> PyResult<Bound<'py, PyDict>> {
+    let collapse_groups = collapse_groups.unwrap_or(false);
     let drop_variables = if let Some(drop_variables) = drop_variables {
         drop_variables
             .iter()
@@ -338,7 +344,14 @@ fn build_grib_dataset<'py>(
         msg_info.insert(k.clone(), (var, level, kind, process));
     }
 
-    let partition_by_level = var_levels.values().any(|levels| levels.len() > 1);
+    // In the default (stable) layout every variable is nested under its level
+    // and kind segments unconditionally, so its group path is a pure function of
+    // its own metadata — the same variable lands at the same path across every
+    // file in a sequence, which is what lets multi-file datacubes concatenate.
+    // With `collapse_groups` we fall back to the content-dependent behavior: a
+    // discriminator only becomes a group axis when at least one variable in this
+    // file actually spans more than one of its values, so a conflict-free file
+    // collapses into a single root dataset.
     let mut var_level_kinds: HashMap<(String, String), HashSet<String>> = HashMap::new();
     for (var, level, kind, process) in msg_info.values() {
         let process_conflict = kind_processes
@@ -355,7 +368,10 @@ fn build_grib_dataset<'py>(
             .or_default()
             .insert(path_kind);
     }
-    let partition_by_kind = var_level_kinds.values().any(|kinds| kinds.len() > 1);
+    let partition_by_level =
+        !collapse_groups || var_levels.values().any(|levels| levels.len() > 1);
+    let partition_by_kind =
+        !collapse_groups || var_level_kinds.values().any(|kinds| kinds.len() > 1);
 
     // group path (0, 1 or 2 segments) -> variable short name -> message keys
     let mut groups: BTreeMap<Vec<String>, HashMap<String, Vec<String>>> = BTreeMap::new();
@@ -446,11 +462,14 @@ fn build_grib_dataset<'py>(
         }
 
         leaf_count += 1;
-        if leaf_count == 1 {
-            single_leaf = Some(node.clone());
+        // Collapsing a lone surviving group up to the root is itself a
+        // content-dependent shortcut, so it only applies under `collapse_groups`.
+        // The stable layout always keeps the full group tree.
+        single_leaf = if collapse_groups && leaf_count == 1 {
+            Some(node.clone())
         } else {
-            single_leaf = None;
-        }
+            None
+        };
 
         match path.as_slice() {
             [] => {

--- a/python/src/dataset.rs
+++ b/python/src/dataset.rs
@@ -368,8 +368,7 @@ fn build_grib_dataset<'py>(
             .or_default()
             .insert(path_kind);
     }
-    let partition_by_level =
-        !collapse_groups || var_levels.values().any(|levels| levels.len() > 1);
+    let partition_by_level = !collapse_groups || var_levels.values().any(|levels| levels.len() > 1);
     let partition_by_kind =
         !collapse_groups || var_level_kinds.values().any(|kinds| kinds.len() > 1);
 

--- a/python/tests/test_dataset_determinism.py
+++ b/python/tests/test_dataset_determinism.py
@@ -66,10 +66,14 @@ def test_message_order_does_not_affect_structure():
 
 def test_isobaric_level_sets_are_complete():
     """Every distinct isobaric level set in the file survives, with the level
-    counts matching the messages actually present (cross-checked with wgrib2)."""
+    counts matching the messages actually present (cross-checked with wgrib2).
+    Uses the collapsed layout so the isobaric hypercube sits directly under
+    `/isobar`; the level sets are identical either way."""
     data = GEFS_FIXTURE.read_bytes()
 
-    coords, dims, groups = dataset_structure(parse_grib_dataset(data))
+    coords, dims, groups = dataset_structure(
+        parse_grib_dataset(data, collapse_groups=True)
+    )
     iso_coords, iso_dims, _ = groups["isobar"]
 
     isobar_sizes = sorted(
@@ -86,12 +90,49 @@ def test_isobaric_level_sets_are_complete():
         )
 
 
+def _group_paths(node, prefix=""):
+    """All group paths that actually carry data variables."""
+    out = []
+    if node.get("data_vars"):
+        out.append(prefix or "/")
+    for name, group in node.get("groups", {}).items():
+        out += _group_paths(group, prefix + "/" + name)
+    return out
+
+
+def test_stable_layout_group_path_is_content_independent():
+    """The default layout pins each variable to a group path that depends only
+    on its own metadata, so the same variable lands at the same path whether or
+    not the file also carries it at other levels. The legacy collapse layout
+    makes the path content-dependent, which is what broke multi-file concat
+    (issue #165)."""
+    SINGLE = REPO_ROOT / "test-data" / "hrrr.t06z.wrfsfcf01-TMP.grib2"  # tmp @ sfc
+    MULTI = REPO_ROOT / "test-data" / "nbm-multilevel-tcdc.grib2"       # tmp @ hag+sfc
+
+    single = _group_paths(parse_grib_dataset(SINGLE.read_bytes()))
+    multi = _group_paths(parse_grib_dataset(MULTI.read_bytes()))
+    # Surface tmp is at the same path in both, despite the multi-level file.
+    assert "/sfc/instant" in single
+    assert "/sfc/instant" in multi
+
+    # Under the collapse layout the surface tmp's path is content-dependent.
+    single_c = _group_paths(parse_grib_dataset(SINGLE.read_bytes(), collapse_groups=True))
+    multi_c = _group_paths(parse_grib_dataset(MULTI.read_bytes(), collapse_groups=True))
+    assert single_c == ["/"]
+    assert "/sfc" in multi_c
+
+
 def test_xarray_engine_dims_are_stable_across_opens():
     """The xarray engine exposes the same dim name per variable on every open."""
     xr = pytest.importorskip("xarray")
 
     def structure():
-        ds = xr.open_dataset(str(GEFS_FIXTURE), engine="gribberish", group="isobar")
+        ds = xr.open_dataset(
+            str(GEFS_FIXTURE),
+            engine="gribberish",
+            group="isobar",
+            collapse_groups=True,
+        )
         try:
             return (
                 {c: tuple(ds[c].values.tolist()) for c in ds.coords if "isobar" in c},

--- a/python/tests/test_index.py
+++ b/python/tests/test_index.py
@@ -22,7 +22,11 @@ def test_use_index_matches_full_scan():
     # Offsets and inferred lengths tile the file exactly.
     assert entries[-1].offset + entries[-1].length == GRIB.stat().st_size
 
-    kwargs = dict(engine="gribberish", only_variables=["wind", "htsgw"])
+    kwargs = dict(
+        engine="gribberish",
+        only_variables=["wind", "htsgw"],
+        collapse_groups=True,
+    )
     full = xr.open_dataset(str(GRIB), **kwargs)
     via_index = xr.open_dataset(str(GRIB), use_index=".idx", **kwargs)
     xr.testing.assert_identical(full, via_index)
@@ -32,6 +36,8 @@ def test_use_index_matches_full_scan():
     no_idx = GRIB.with_name("multi_1.at_10m.t12z.f147.grib2")
     with pytest.raises(FileNotFoundError, match="No index file"):
         xr.open_dataset(str(no_idx), engine="gribberish", use_index=".idx")
-    xr.open_dataset(str(no_idx), engine="gribberish", use_index="auto")
+    xr.open_dataset(
+        str(no_idx), engine="gribberish", use_index="auto", collapse_groups=True
+    )
     with pytest.raises(ValueError, match="use_index must be"):
         xr.open_dataset(str(no_idx), engine="gribberish", use_index=True)

--- a/python/tests/test_virtualizarr.py
+++ b/python/tests/test_virtualizarr.py
@@ -24,10 +24,38 @@ def _store_for(filename, **kwargs):
     return GribberishParser(**kwargs)(url, registry)
 
 
-def test_no_conflict_single_root_dataset():
-    """A conflict-free file becomes a single virtual dataset, levels and ensemble
-    members as dimensions (this ERA5 EDA file has 10 GRIB1 members)."""
+def _collapsed_store_for(filename, **kwargs):
+    """A store built with the legacy collapse-to-root layout, for tests that
+    just need a flat single dataset to exercise an orthogonal feature."""
+    return _store_for(filename, collapse_groups=True, **kwargs)
+
+
+def test_stable_layout_nests_under_level_and_kind():
+    """By default every variable is nested under its surface-type and product
+    kind, even when nothing in the file conflicts — so the group path is a pure
+    function of the variable's own metadata. This ERA5 EDA file has a single
+    isobaric instantaneous hypercube (10 GRIB1 members), which lands at
+    `/isobar/instant` rather than collapsing to the root."""
     store = _store_for("era5-levels-members.grib")
+    vdt = store.to_virtual_datatree()
+
+    assert set(vdt.children) == {"isobar"}
+    iso = vdt["isobar/instant"].to_dataset()
+    assert {"t", "z"}.issubset(set(iso.data_vars))
+    assert dict(iso.sizes) == {
+        "time": 4,
+        "isobar": 2,
+        "number": 10,
+        "latitude": 61,
+        "longitude": 120,
+    }
+    assert iso["t"].dims == ("time", "isobar", "number", "latitude", "longitude")
+
+
+def test_collapse_groups_single_root_dataset():
+    """`collapse_groups=True` folds a conflict-free file back into a single
+    virtual dataset, with levels and ensemble members as dimensions."""
+    store = _collapsed_store_for("era5-levels-members.grib")
     vds = store.to_virtual_dataset()
 
     assert dict(vds.sizes) == {
@@ -42,27 +70,61 @@ def test_no_conflict_single_root_dataset():
     assert vds["t"].dims == ("time", "isobar", "number", "latitude", "longitude")
 
 
+def test_group_paths_are_content_independent():
+    """The whole point of the stable default: the same variable lands at the
+    same group path regardless of what else is in the file.
+
+    `tmp` exists at the surface in both fixtures, but only spans a second level
+    (height-above-ground) in the NBM file. Under the legacy `collapse_groups`
+    layout the surface `tmp` lands at `/` in the single-level file but `/sfc` in
+    the multi-level one — different paths for the same variable, which breaks
+    concatenation across a forecast sequence. The default layout pins it to
+    `/sfc/instant` in both."""
+    single_level = "hrrr.t06z.wrfsfcf01-TMP.grib2"  # tmp at sfc only
+    multi_level = "nbm-multilevel-tcdc.grib2"        # tmp at hag AND sfc
+
+    def tmp_paths(filename, **kwargs):
+        vdt = _store_for(filename, **kwargs).to_virtual_datatree()
+        return sorted(
+            node.path
+            for node in vdt.subtree
+            if "tmp" in vdt[node.path].dataset.data_vars
+        )
+
+    # Stable default: surface tmp is at /sfc/instant in both files.
+    assert "/sfc/instant" in tmp_paths(single_level)
+    assert "/sfc/instant" in tmp_paths(multi_level)
+
+    # Legacy collapse layout: the surface tmp's path depends on the file.
+    assert tmp_paths(single_level, collapse_groups=True) == ["/"]
+    assert "/sfc" in tmp_paths(multi_level, collapse_groups=True)
+    assert "/sfc/instant" not in tmp_paths(multi_level, collapse_groups=True)
+
+
 def test_conflict_produces_datatree_groups():
-    """Conflicting product kinds become a DataTree of standalone groups."""
+    """Conflicting product kinds become a DataTree of standalone groups. These
+    S2S products are all at height-above-ground, so they nest under `/hag`."""
     store = _store_for("s2s-pdt9-pdt10-pdt12.grib2")
     vdt = store.to_virtual_datatree()
 
-    groups = set(vdt.children)
+    assert set(vdt.children) == {"hag"}
+    groups = set(vdt["hag"].children)
     # percentile product is its own group, with the percentile dim inside it
     assert "min24h_pctl" in groups
-    pctl = store.to_virtual_datatree()["min24h_pctl"]
+    pctl = store.to_virtual_datatree()["hag/min24h_pctl"]
     assert "percentile" in pctl.dims
     # between-limit probabilities split per (lower, upper) pair
     assert len([g for g in groups if "prob_between_inc" in g]) == 3
 
 
 def test_level_type_conflict_groups():
-    """A variable spanning multiple level types splits by level type."""
+    """A variable spanning multiple level types splits by level type; each level
+    then nests by product kind (this GEFS file is an ensemble mean)."""
     store = _store_for("geavg.t12z.pgrb2a.0p50.f000")
     vdt = store.to_virtual_datatree()
     assert {"hag", "isobar", "sfc", "msl"}.issubset(set(vdt.children))
 
-    iso = vdt["isobar"].to_dataset()
+    iso = vdt["isobar/mean"].to_dataset()
     assert {"tmp", "ugrd", "vgrd", "rh", "hgt"}.issubset(set(iso.data_vars))
     # isobaric temperature keeps its vertical level dimension
     assert iso["tmp"].shape == (1, 10, 361, 720)
@@ -70,28 +132,27 @@ def test_level_type_conflict_groups():
 
 def test_missing_level_does_not_break_datatree():
     """A variable with a missing/unrecognized surface type must not create an
-    unnamed group. When a file also partitions by level type, such a variable
-    used to land in an empty-named group, which corrupts the Zarr/datatree
-    hierarchy and made `to_virtual_datatree` raise `KeyError: ... at <level>`.
-    The fixture has TMP at two levels (forcing a level split) plus TCDC on a
-    "reserved" surface that gribberish maps to a missing level type.
+    unnamed group. It keeps its product-kind segment but no level segment, so it
+    lands at a top-level kind group (`/instant`) rather than an empty-named one.
+    The fixture has TMP at two levels plus TCDC on a "reserved" surface that
+    gribberish maps to a missing level type.
     """
     store = _store_for("nbm-multilevel-tcdc.grib2")
     vdt = store.to_virtual_datatree()
 
     keys = {k for k, _ in vdt.subtree_with_keys}
     assert "" not in keys, "an unnamed group leaked into the hierarchy"
-    # The level split still happens for the well-formed variable.
+    # The well-formed variable still splits by level type.
     assert {"hag", "sfc"}.issubset(set(vdt.children))
-    # The missing-level variable is preserved at the root rather than dropped.
-    assert "tcdc" in vdt.to_dataset().data_vars
+    # The missing-level variable is preserved in a top-level kind group.
+    assert "tcdc" in vdt["instant"].dataset.data_vars
 
 
 def test_decoded_values_match_direct_parse():
     """Reading a chunk through the store decodes the exact message the manifest
     points to (the gribberish codec resolves at read time)."""
     fname = "era5-levels-members.grib"
-    store = _store_for(fname)
+    store = _collapsed_store_for(fname)
     z = zarr.open(store, mode="r")
 
     chunk = np.asarray(z["t"][0, 0, 0])  # (time0, isobar0, number0) -> (lat, lon)
@@ -99,7 +160,7 @@ def test_decoded_values_match_direct_parse():
 
     with open(TEST_DATA / fname, "rb") as f:
         data = f.read()
-    ds = parse_grib_dataset(data)
+    ds = parse_grib_dataset(data, collapse_groups=True)
     offset, size = ds["data_vars"]["t"]["values"]["offsets"][0]
     expected = parse_grib_array(data[offset : offset + size], 0).reshape(61, 120)
 
@@ -109,7 +170,7 @@ def test_decoded_values_match_direct_parse():
 def test_inline_coordinates_decode():
     """Derived coordinates (time / level) are inlined and decode correctly."""
     fname = "era5-levels-members.grib"
-    store = _store_for(fname)
+    store = _collapsed_store_for(fname)
     z = zarr.open(store, mode="r")
 
     isobar = np.asarray(z["isobar"][:])
@@ -122,7 +183,7 @@ def test_inline_coordinates_decode():
 def test_projected_grid_latlon_are_references():
     """A projected (Lambert) grid keeps 2D lat/lon as byte references decoded
     by the gribberish codec."""
-    store = _store_for("hrrr.t06z.wrfsfcf01-TMP.grib2")
+    store = _collapsed_store_for("hrrr.t06z.wrfsfcf01-TMP.grib2")
     vds = store.to_virtual_dataset()
 
     assert vds["latitude"].dims == ("y", "x")
@@ -146,7 +207,7 @@ def test_cf_grid_mapping_scalar_coordinate():
         "gfs.t18z.pgrb2.0p25.f186-RH.grib2": "latitude_longitude",
     }
     for fname, grid_mapping_name in cases.items():
-        store = _store_for(fname)
+        store = _collapsed_store_for(fname)
         vds = store.to_virtual_dataset()
 
         assert "spatial_ref" in vds.coords
@@ -166,7 +227,7 @@ def test_cf_grid_mapping_scalar_coordinate():
 
 def test_ensemble_member_dimension():
     """Ensemble member number is a dimension, not a group."""
-    store = _store_for("aifs-ens-cf-t500.grib2")
+    store = _collapsed_store_for("aifs-ens-cf-t500.grib2")
     vds = store.to_virtual_dataset()
 
     assert "number" in vds.coords
@@ -174,7 +235,7 @@ def test_ensemble_member_dimension():
 
 
 def test_drop_and_only_variables():
-    store = _store_for("ecmwf-ifs-oper-surface.grib2", only_variables=["tcc"])
+    store = _collapsed_store_for("ecmwf-ifs-oper-surface.grib2", only_variables=["tcc"])
     vds = store.to_virtual_dataset()
     assert set(vds.data_vars) == {"tcc"}
 
@@ -185,16 +246,16 @@ def test_use_index_matches_full_scan():
     file: identical structure, identical chunk manifests (real file offsets),
     identical decoded values."""
     fname = "gfswave.t18z.atlocn.0p16.f001.grib2"
-    full = _store_for(fname).to_virtual_dataset()
-    via_index = _store_for(fname, use_index=".idx").to_virtual_dataset()
+    full = _collapsed_store_for(fname).to_virtual_dataset()
+    via_index = _collapsed_store_for(fname, use_index=".idx").to_virtual_dataset()
 
     assert dict(via_index.sizes) == dict(full.sizes)
     assert set(via_index.data_vars) == set(full.data_vars)
     for name in full.data_vars:
         assert via_index[name].data.manifest == full[name].data.manifest
 
-    z_full = zarr.open(_store_for(fname), mode="r")
-    z_index = zarr.open(_store_for(fname, use_index=".idx"), mode="r")
+    z_full = zarr.open(_collapsed_store_for(fname), mode="r")
+    z_index = zarr.open(_collapsed_store_for(fname, use_index=".idx"), mode="r")
     np.testing.assert_array_equal(
         np.asarray(z_index["wind"][0]), np.asarray(z_full["wind"][0])
     )
@@ -207,8 +268,10 @@ def test_adjust_longitude_range_global_grid():
     fname = "gfs.t18z.pgrb2.0p25.f186-RH.grib2"
     nx, roll = 1440, 720
 
-    plain = _store_for(fname).to_virtual_dataset()
-    wrapped = _store_for(fname, adjust_longitude_range=True).to_virtual_dataset()
+    plain = _collapsed_store_for(fname).to_virtual_dataset()
+    wrapped = _collapsed_store_for(
+        fname, adjust_longitude_range=True
+    ).to_virtual_dataset()
 
     # default coordinate is the native 0..360 range
     np.testing.assert_array_equal(plain.longitude.values[[0, -1]], [0.0, 359.75])
@@ -220,8 +283,10 @@ def test_adjust_longitude_range_global_grid():
 
     # data stays aligned with the coordinate: reading through the wrapped store
     # equals the plain store rolled along longitude by the same split column.
-    z_plain = zarr.open(_store_for(fname), mode="r")
-    z_wrapped = zarr.open(_store_for(fname, adjust_longitude_range=True), mode="r")
+    z_plain = zarr.open(_collapsed_store_for(fname), mode="r")
+    z_wrapped = zarr.open(
+        _collapsed_store_for(fname, adjust_longitude_range=True), mode="r"
+    )
     plain_data = np.asarray(z_plain["rh"][...])
     wrapped_data = np.asarray(z_wrapped["rh"][...])
     cols = (np.arange(nx) + roll) % nx
@@ -248,8 +313,10 @@ def test_adjust_longitude_range_start_at_antimeridian():
     move (roll == 0), exercising the relabel-only branch."""
     fname = "aifs-single-t500.grib2"
 
-    plain = _store_for(fname).to_virtual_dataset()
-    wrapped = _store_for(fname, adjust_longitude_range=True).to_virtual_dataset()
+    plain = _collapsed_store_for(fname).to_virtual_dataset()
+    wrapped = _collapsed_store_for(
+        fname, adjust_longitude_range=True
+    ).to_virtual_dataset()
 
     # native coordinate wraps mid-array (180..359.75, then 0..179.75)
     assert plain.longitude.values[0] == 180.0 and plain.longitude.values[-1] == 179.75
@@ -261,8 +328,10 @@ def test_adjust_longitude_range_start_at_antimeridian():
     assert np.all(np.diff(lon) > 0)
 
     # data is unchanged because the columns were already in -180..180 order
-    z_plain = zarr.open(_store_for(fname), mode="r")
-    z_wrapped = zarr.open(_store_for(fname, adjust_longitude_range=True), mode="r")
+    z_plain = zarr.open(_collapsed_store_for(fname), mode="r")
+    z_wrapped = zarr.open(
+        _collapsed_store_for(fname, adjust_longitude_range=True), mode="r"
+    )
     np.testing.assert_array_equal(
         np.asarray(z_wrapped["tmp"][...]), np.asarray(z_plain["tmp"][...])
     )
@@ -271,8 +340,10 @@ def test_adjust_longitude_range_start_at_antimeridian():
 def test_adjust_longitude_range_default_off_unchanged():
     """Default-off parser is byte-for-byte the existing behaviour."""
     fname = "gfs.t18z.pgrb2.0p25.f186-RH.grib2"
-    default = _store_for(fname).to_virtual_dataset()
-    explicit_off = _store_for(fname, adjust_longitude_range=False).to_virtual_dataset()
+    default = _collapsed_store_for(fname).to_virtual_dataset()
+    explicit_off = _collapsed_store_for(
+        fname, adjust_longitude_range=False
+    ).to_virtual_dataset()
     np.testing.assert_array_equal(
         default.longitude.values, explicit_off.longitude.values
     )
@@ -303,7 +374,7 @@ def test_layer_variable_distinguished_by_second_surface():
     0-1000m vs 0-6000m wind shear) must not collapse into a single chunk slot.
     The second (top) fixed surface becomes the vertical coordinate so each
     layer maps to its own message."""
-    store = _store_for("hrrr.t01z.wrfsfcf01-VVCSH-VUCSH.grib2")
+    store = _collapsed_store_for("hrrr.t01z.wrfsfcf01-VVCSH-VUCSH.grib2")
     vds = store.to_virtual_dataset()
 
     assert {"vvcsh", "vucsh"}.issubset(set(vds.data_vars))

--- a/python/tests/test_xarray_backend.py
+++ b/python/tests/test_xarray_backend.py
@@ -7,7 +7,8 @@ from gribberish.gribberish_backend import GribberishBackend
 
 
 def test_xarray_backend_gefs_ensemble():
-    """GEFS ensemble-mean file splits into standalone groups by level type."""
+    """GEFS ensemble-mean file splits into standalone groups, nested by level
+    type then product kind (here the ensemble `mean`)."""
     path = "./../test-data/geavg.t12z.pgrb2a.0p50.f000"
 
     # Opening without a group raises, listing the available groups to choose.
@@ -19,7 +20,7 @@ def test_xarray_backend_gefs_ensemble():
     assert {"hag", "isobar", "sfc", "msl"}.issubset(set(dt.children))
 
     # Open one group directly; variables keep their plain short names.
-    iso = xr.open_dataset(path, engine="gribberish", group="isobar")
+    iso = xr.open_dataset(path, engine="gribberish", group="isobar/mean")
     assert {"tmp", "ugrd", "vgrd", "rh", "hgt"}.issubset(set(iso.data_vars))
     assert "time" in iso.coords
     assert "latitude" in iso.coords
@@ -28,18 +29,24 @@ def test_xarray_backend_gefs_ensemble():
     assert iso.tmp.values.shape == (1, 10, 361, 720)
 
     # Single-level fields live in their level-type group with no vertical dim.
-    hag = xr.open_dataset(path, engine="gribberish", group="hag")
+    hag = xr.open_dataset(path, engine="gribberish", group="hag/mean")
     assert hag.tmp.values.shape == (1, 361, 720)
-    cape = xr.open_dataset(path, engine="gribberish", group="pres_diff")
+    cape = xr.open_dataset(path, engine="gribberish", group="pres_diff/mean")
     assert cape.cape.values.shape == (1, 361, 720)
 
 
 def test_xarray_filters_collapse_single_remaining_group():
-    """Variable/attribute filters can resolve conflicting hypercubes."""
+    """With `collapse_groups`, variable/attribute filters that leave a single
+    hypercube resolve to one root dataset."""
     repo_root = Path(__file__).resolve().parents[2]
     fixture = repo_root / "test-data" / "geavg.t12z.pgrb2a.0p50.f000"
 
-    ds = xr.open_dataset(str(fixture), engine="gribberish", only_variables=["prmsl"])
+    ds = xr.open_dataset(
+        str(fixture),
+        engine="gribberish",
+        only_variables=["prmsl"],
+        collapse_groups=True,
+    )
     assert set(ds.data_vars) == {"prmsl"}
     assert tuple(ds.prmsl.shape) == (1, 361, 720)
 
@@ -47,6 +54,7 @@ def test_xarray_filters_collapse_single_remaining_group():
         str(fixture),
         engine="gribberish",
         filter_by_attrs={"fixed_surface_type": "mean sea level"},
+        collapse_groups=True,
     )
     assert set(ds.data_vars) == {"prmsl"}
     assert tuple(ds.prmsl.shape) == (1, 361, 720)
@@ -54,8 +62,13 @@ def test_xarray_filters_collapse_single_remaining_group():
 
 def test_xarray_backend_era5_grib1():
     """Test reading ERA5 GRIB1 file with levels and members using xarray backend"""
-    # Open the ERA5 GRIB1 file using the gribberish backend
-    ds = xr.open_dataset("./../test-data/era5-levels-members.grib", engine="gribberish")
+    # Open the ERA5 GRIB1 file using the gribberish backend (collapsed to one
+    # dataset; this test is about decoding, not the group layout).
+    ds = xr.open_dataset(
+        "./../test-data/era5-levels-members.grib",
+        engine="gribberish",
+        collapse_groups=True,
+    )
 
     # Verify dataset was loaded
     assert ds is not None
@@ -95,14 +108,16 @@ def test_xarray_backend_era5_grib1_ensemble():
     import numpy as np
 
     ds = xr.open_dataset(
-        "./../test-data/era5-levels-members.grib", engine="gribberish"
+        "./../test-data/era5-levels-members.grib",
+        engine="gribberish",
+        collapse_groups=True,
     )
 
     # 10 ensemble members decoded from the ECMWF GRIB1 PDS local extension
     assert "number" in ds.coords
     assert ds.sizes["number"] == 10
     np.testing.assert_array_equal(ds.number.values, np.arange(10))
-    # No conflict -> members are a dimension, not a group
+    # No conflict (and collapsed) -> members are a dimension, not a group
     assert "number" in ds.t.dims
 
 
@@ -119,7 +134,8 @@ def test_xarray_open_datatree_can_guess_gribberish_engine():
     fixture = repo_root / "test-data" / "hrrr.t06z.wrfsfcf01-TMP.grib2"
 
     dt = xr.open_datatree(str(fixture))
-    assert set(dt.to_dataset().data_vars) == {"tmp"}
+    # Default stable layout nests the surface field under /sfc/instant.
+    assert set(dt["sfc/instant"].dataset.data_vars) == {"tmp"}
 
 
 def test_xarray_backend_complex_packing_missing_values():
@@ -132,7 +148,7 @@ def test_xarray_backend_complex_packing_missing_values():
 
     repo_root = Path(__file__).resolve().parents[2]
     fixture = repo_root / "test-data" / "gfs.t12z.pgrb2.0p25.f023-PV-TMP-missing.grib2"
-    ds = xr.open_dataset(str(fixture), engine="gribberish")
+    ds = xr.open_dataset(str(fixture), engine="gribberish", collapse_groups=True)
 
     arr = np.asarray(ds["tmp"].values)
     finite = np.isfinite(arr)
@@ -146,7 +162,7 @@ def test_xarray_backend_ecmwf_soil_tiny_fixture():
     """Test reading ECMWF soil GRIB1 file with 8 soil variables."""
     repo_root = Path(__file__).resolve().parents[2]
     fixture = repo_root / "test-data" / "ecmwf_soil_8vars_tiny.grib1"
-    ds = xr.open_dataset(str(fixture), engine="gribberish")
+    ds = xr.open_dataset(str(fixture), engine="gribberish", collapse_groups=True)
 
     # Should have 8 soil variables: 4 soil temperature layers + 4 soil moisture layers
     expected_vars = {"stl1", "stl2", "stl3", "stl4", "swvl1", "swvl2", "swvl3", "swvl4"}
@@ -167,7 +183,7 @@ def test_multiple_variables_at_same_level():
     import numpy as np
 
     ds = xr.open_dataset(
-        "./../test-data/geavg.t12z.pgrb2a.0p50.f000", engine="gribberish", group="hag"
+        "./../test-data/geavg.t12z.pgrb2a.0p50.f000", engine="gribberish", group="hag/mean"
     )
 
     # Multiple variables exist in the 'hag' (height above ground) group
@@ -228,7 +244,7 @@ def test_longitude_normalization_grib2():
     import numpy as np
 
     ds = xr.open_dataset(
-        "./../test-data/geavg.t12z.pgrb2a.0p50.f000", engine="gribberish", group="hag"
+        "./../test-data/geavg.t12z.pgrb2a.0p50.f000", engine="gribberish", group="hag/mean"
     )
 
     # Get longitude coordinate
@@ -258,7 +274,11 @@ def test_longitude_normalization_grib1():
     """
     import numpy as np
 
-    ds = xr.open_dataset("./../test-data/era5-levels-members.grib", engine="gribberish")
+    ds = xr.open_dataset(
+        "./../test-data/era5-levels-members.grib",
+        engine="gribberish",
+        collapse_groups=True,
+    )
 
     # Get longitude coordinate
     lons = ds.longitude.values
@@ -282,7 +302,7 @@ def test_latitude_values():
     import numpy as np
 
     ds = xr.open_dataset(
-        "./../test-data/geavg.t12z.pgrb2a.0p50.f000", engine="gribberish", group="hag"
+        "./../test-data/geavg.t12z.pgrb2a.0p50.f000", engine="gribberish", group="hag/mean"
     )
 
     # Get latitude coordinate
@@ -308,7 +328,7 @@ def test_xarray_backend_aifs_ensemble():
     """Test reading AIFS ensemble GRIB2 file with ensemble member dimension."""
     repo_root = Path(__file__).resolve().parents[2]
     fixture = repo_root / "test-data" / "aifs-ens-cf-t500.grib2"
-    ds = xr.open_dataset(str(fixture), engine="gribberish")
+    ds = xr.open_dataset(str(fixture), engine="gribberish", collapse_groups=True)
 
     assert "tmp" in ds.data_vars
     assert "number" in ds.coords
@@ -334,11 +354,12 @@ def test_xarray_backend_s2s_percentile_probability():
         xr.open_dataset(path, engine="gribberish")
 
     dt = xr.open_datatree(path, engine="gribberish")
-    groups = set(dt.children)
+    # All products are at height-above-ground, so the kind groups nest under hag.
+    groups = set(dt["hag"].children)
 
     # The percentile product is its own group, with a percentile dimension.
     assert "min24h_pctl" in groups, f"groups: {sorted(groups)}"
-    pctl = xr.open_dataset(path, engine="gribberish", group="min24h_pctl")
+    pctl = xr.open_dataset(path, engine="gribberish", group="hag/min24h_pctl")
     assert "percentile" in pctl.coords
     np.testing.assert_array_equal(sorted(pctl.percentile.values), [1, 50, 99])
     assert "percentile" in pctl.tmp.dims
@@ -351,13 +372,13 @@ def test_xarray_backend_s2s_percentile_probability():
     # limit is preserved in the `probability_limit` attribute, mirroring how a
     # single vertical level collapses to `fixed_surface_value`.
     abnorm = next(g for g in groups if "prob_abnorm" in g)
-    prob = xr.open_dataset(path, engine="gribberish", group=abnorm)
+    prob = xr.open_dataset(path, engine="gribberish", group=f"hag/{abnorm}")
     assert "threshold" not in prob.tmp.dims
     assert prob.tmp.attrs["probability_limit"] == "0"
 
     # Probability groups never carry a percentile dimension.
     for gname in (g for g in groups if "prob" in g):
-        prob = xr.open_dataset(path, engine="gribberish", group=gname)
+        prob = xr.open_dataset(path, engine="gribberish", group=f"hag/{gname}")
         assert "percentile" not in prob.tmp.dims
 
 
@@ -375,7 +396,7 @@ def test_xarray_backend_prob_above_upper_limit_threshold():
 
     repo_root = Path(__file__).resolve().parents[2]
     fixture = repo_root / "test-data" / "nbm-pwat-prob-above.grib2"
-    ds = xr.open_dataset(str(fixture), engine="gribberish")
+    ds = xr.open_dataset(str(fixture), engine="gribberish", collapse_groups=True)
 
     assert "threshold" in ds.coords
     assert "threshold" in ds.pwat.dims
@@ -396,7 +417,7 @@ def test_cf_grid_mapping_metadata():
         "./../test-data/gfs.t18z.pgrb2.0p25.f186-RH.grib2": "latitude_longitude",
     }
     for path, grid_mapping_name in cases.items():
-        ds = xr.open_dataset(path, engine="gribberish")
+        ds = xr.open_dataset(path, engine="gribberish", collapse_groups=True)
 
         assert "spatial_ref" in ds.coords
         assert ds["spatial_ref"].shape == ()

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gribberish-types"
-version = "1.2.0"
+version = "1.3.0"
 authors = ["Matthew Iannucci <mpiannucci@gmail.com>"]
 description = "Common types for the gribberish crate"
 edition = "2021"


### PR DESCRIPTION
Closes #165.

Default to a content-independent group layout: every variable nests under its surface-type and product-kind subgroups (e.g. `/hag/instant`), so the same variable lands at the same path across files and multi-file datacubes concatenate. Pass `collapse_groups=True` for the prior collapse-to-root behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)