### PR TITLE
Bump version to 1.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -444,7 +444,7 @@ checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
 name = "gribberish"
-version = "1.4.0"
+version = "1.5.0"
 dependencies = [
  "bitflags 2.6.0",
  "bitvec",
@@ -464,7 +464,7 @@ dependencies = [
 
 [[package]]
 name = "gribberish-macros"
-version = "1.4.0"
+version = "1.5.0"
 dependencies = [
  "gribberish-types",
  "quote",
@@ -473,11 +473,11 @@ dependencies = [
 
 [[package]]
 name = "gribberish-types"
-version = "1.4.0"
+version = "1.5.0"
 
 [[package]]
 name = "gribberish_js"
-version = "1.4.0"
+version = "1.5.0"
 dependencies = [
  "chrono",
  "gribberish",
@@ -488,7 +488,7 @@ dependencies = [
 
 [[package]]
 name = "gribberishpy"
-version = "1.4.0"
+version = "1.5.0"
 dependencies = [
  "gribberish",
  "numpy",

--- a/gribberish/Cargo.toml
+++ b/gribberish/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gribberish"
-version = "1.4.0"
+version = "1.5.0"
 authors = ["Matthew Iannucci <mpiannucci@gmail.com>"]
 description = "Parse grib 2 files with Rust"
 edition = "2021"
@@ -11,8 +11,8 @@ categories = ["science", "encoding", "compression"]
 exclude = ["tests"]
 
 [dependencies]
-gribberish-types = { path = "../types", version = "1.4.0" }
-gribberish-macros = { path = "../macros", version = "1.4.0" }
+gribberish-types = { path = "../types", version = "1.5.0" }
+gribberish-macros = { path = "../macros", version = "1.5.0" }
 chrono = "0.4"
 openjpeg-sys = { version = "1.0.3", optional = true }
 png = { version = "0.17.2", optional = true }

--- a/js/Cargo.toml
+++ b/js/Cargo.toml
@@ -3,7 +3,7 @@
 authors = ["Matthew Iannucci <mpiannucci@gmail.com>"]
 edition = "2024"
 name = "gribberish_js"
-version = "1.4.0"
+version = "1.5.0"
 
 [lib]
 crate-type = ["cdylib"]
@@ -11,11 +11,11 @@ crate-type = ["cdylib"]
 [dependencies]
 napi = { version = "3.0.0", features = ["chrono_date"] }
 napi-derive = "3.0.0"
-gribberish = { path = "../gribberish", version = "1.4.0", default-features = false, features = ["png"] }
+gribberish = { path = "../gribberish", version = "1.5.0", default-features = false, features = ["png"] }
 chrono = "0.4"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-gribberish = { path = "../gribberish", version = "1.4.0", default-features = false, features = ["png", "jpeg"] }
+gribberish = { path = "../gribberish", version = "1.5.0", default-features = false, features = ["png", "jpeg"] }
 
 [build-dependencies]
 napi-build = "2"

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mattnucc/gribberish",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "JavaScript bindings for gribberish, a GRIB2 parsing library",
   "main": "index.js",
   "repository": {

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gribberish-macros"
-version = "1.4.0"
+version = "1.5.0"
 authors = ["Matthew Iannucci <mpiannucci@gmail.com>"]
 description = "Procedural macros for the gribberish crate"
 edition = "2021"
@@ -10,7 +10,7 @@ repository = "https://github.com/mpiannucci/gribberish"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-gribberish-types = { path = "./../types", version = "1.4.0" }
+gribberish-types = { path = "./../types", version = "1.5.0" }
 syn = { version = "1.0", features = ["full"] }
 quote = "1.0"
 

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gribberishpy"
-version = "1.4.0"
+version = "1.5.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -10,5 +10,5 @@ crate-type = ["cdylib"]
 
 [dependencies]
 pyo3 = "0.27.0"
-gribberish = { path = "../gribberish", version = "1.4.0" }
+gribberish = { path = "../gribberish", version = "1.5.0" }
 numpy = "0.27.0"

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gribberish-types"
-version = "1.4.0"
+version = "1.5.0"
 authors = ["Matthew Iannucci <mpiannucci@gmail.com>"]
 description = "Common types for the gribberish crate"
 edition = "2021"


### PR DESCRIPTION
## Summary
- Bump all gribberish crates and the npm package from 1.4.0 to 1.5.0 in lockstep
- Regenerate Cargo.lock

🤖 Generated with [Claude Code](https://claude.com/claude-code)